### PR TITLE
Change properties from `protected` to `public`

### DIFF
--- a/src/API/Aktion.php
+++ b/src/API/Aktion.php
@@ -8,9 +8,9 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Aktion
- * Aktion für Objekt. Wenn nicht vorhanden, dann "ADD", als neu.
- *  Change= Update der Objektdaten, Delete = Löschen des Objektes
- *  Referenz= Die Möglichkeit Objekte in Portalen als Verkauft oder Archiv zu definieren.
+ * Aktion fÃ¼r Objekt. Wenn nicht vorhanden, dann "ADD", als neu.
+ *  Change= Update der Objektdaten, Delete = LÃ¶schen des Objektes
+ *  Referenz= Die MÃ¶glichkeit Objekte in Portalen als ÂVerkauftÂ oder ÂArchivÂ zu definieren.
  * @XmlRoot("aktion")
  */
 class Aktion
@@ -25,7 +25,7 @@ class Aktion
      * optional
      * @see AKTIONART_* constants
      */
-    protected string $aktionart = '';
+    public string $aktionart = '';
 
     public function getAktionart(): ?string
     {

--- a/src/API/Alter.php
+++ b/src/API/Alter.php
@@ -22,7 +22,7 @@ class Alter
      * optional
      * @see ALTER_ATTR_* constants
      */
-    protected string $alterAttr = '';
+    public string $alterAttr = '';
 
     public function getAlterAttr(): ?string
     {

--- a/src/API/Anbieter.php
+++ b/src/API/Anbieter.php
@@ -15,59 +15,59 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Anbieter
 {
     /** @Type("string") */
-    protected ?string $anbieternr = null;
+    public ?string $anbieternr = null;
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $firma = '';
+    public string $firma = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $openimmoAnid = '';
+    public string $openimmoAnid = '';
 
     /** @Type("string") */
-    protected ?string $lizenzkennung = null;
+    public ?string $lizenzkennung = null;
 
     /** @Type("Ujamii\OpenImmo\API\Anhang") */
-    protected ?Anhang $anhang = null;
+    public ?Anhang $anhang = null;
 
     /**
      * @XmlList(inline = true, entry = "immobilie")
      * @Type("array<Ujamii\OpenImmo\API\Immobilie>")
      * @SkipWhenEmpty
      */
-    protected array $immobilie = [];
+    public array $immobilie = [];
 
     /** @Type("string") */
-    protected ?string $impressum = null;
+    public ?string $impressum = null;
 
     /** @Type("Ujamii\OpenImmo\API\ImpressumStrukt") */
-    protected ?ImpressumStrukt $impressumStrukt = null;
+    public ?ImpressumStrukt $impressumStrukt = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getAnbieternr(): ?string
     {

--- a/src/API/AngeschlGastronomie.php
+++ b/src/API/AngeschlGastronomie.php
@@ -20,7 +20,7 @@ class AngeschlGastronomie
      * @SerializedName("HOTELRESTAURANT")
      * optional
      */
-    protected ?bool $hotelrestaurant = null;
+    public ?bool $hotelrestaurant = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class AngeschlGastronomie
      * @SerializedName("BAR")
      * optional
      */
-    protected ?bool $bar = null;
+    public ?bool $bar = null;
 
     public function getHotelrestaurant(): ?bool
     {

--- a/src/API/Anhaenge.php
+++ b/src/API/Anhaenge.php
@@ -19,28 +19,28 @@ class Anhaenge
      * @Type("array<Ujamii\OpenImmo\API\Anhang>")
      * @SkipWhenEmpty
      */
-    protected array $anhang = [];
+    public array $anhang = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     /**
      * Returns array of array
@@ -102,7 +102,7 @@ class Anhaenge
         array $anhang = [],
         array $userDefinedSimplefield = [],
         array $userDefinedAnyfield = [],
-        array $userDefinedExtend = []
+        array $userDefinedExtend = [],
     ) {
         $this->anhang = $anhang;
         $this->userDefinedSimplefield = $userDefinedSimplefield;

--- a/src/API/Anhang.php
+++ b/src/API/Anhang.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Anhang
- * Element für Anhänge
+ * Element fÃ¼r AnhÃ¤nge
  * @XmlRoot("anhang")
  */
 class Anhang
@@ -39,7 +39,7 @@ class Anhang
      * required
      * @see LOCATION_* constants
      */
-    protected string $location = '';
+    public string $location = '';
 
     /**
      * @Type("string")
@@ -47,22 +47,22 @@ class Anhang
      * optional
      * @see GRUPPE_* constants
      */
-    protected string $gruppe = '';
+    public string $gruppe = '';
 
     /** @Type("string") */
-    protected ?string $anhangtitel = null;
+    public ?string $anhangtitel = null;
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $format = '';
+    public string $format = '';
 
     /** @Type("Ujamii\OpenImmo\API\Check") */
-    protected ?Check $check = null;
+    public ?Check $check = null;
 
     /** @Type("Ujamii\OpenImmo\API\Daten") */
-    protected ?Daten $daten = null;
+    public ?Daten $daten = null;
 
     public function getLocation(): string
     {
@@ -136,7 +136,7 @@ class Anhang
         ?string $anhangtitel = null,
         string $format = '',
         ?Check $check = null,
-        ?Daten $daten = null
+        ?Daten $daten = null,
     ) {
         $this->location = $location;
         $this->gruppe = $gruppe;

--- a/src/API/Ausbaustufe.php
+++ b/src/API/Ausbaustufe.php
@@ -20,7 +20,7 @@ class Ausbaustufe
      * @SerializedName("BAUSATZHAUS")
      * optional
      */
-    protected ?bool $bausatzhaus = null;
+    public ?bool $bausatzhaus = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Ausbaustufe
      * @SerializedName("AUSBAUHAUS")
      * optional
      */
-    protected ?bool $ausbauhaus = null;
+    public ?bool $ausbauhaus = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Ausbaustufe
      * @SerializedName("SCHLUESSELFERTIGMITKELLER")
      * optional
      */
-    protected ?bool $schluesselfertigmitkeller = null;
+    public ?bool $schluesselfertigmitkeller = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Ausbaustufe
      * @SerializedName("SCHLUESSELFERTIGOHNEBODENPLATTE")
      * optional
      */
-    protected ?bool $schluesselfertigohnebodenplatte = null;
+    public ?bool $schluesselfertigohnebodenplatte = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Ausbaustufe
      * @SerializedName("SCHLUESSELFERTIGMITBODENPLATTE")
      * optional
      */
-    protected ?bool $schluesselfertigmitbodenplatte = null;
+    public ?bool $schluesselfertigmitbodenplatte = null;
 
     public function getBausatzhaus(): ?bool
     {
@@ -114,7 +114,7 @@ class Ausbaustufe
         ?bool $ausbauhaus = null,
         ?bool $schluesselfertigmitkeller = null,
         ?bool $schluesselfertigohnebodenplatte = null,
-        ?bool $schluesselfertigmitbodenplatte = null
+        ?bool $schluesselfertigmitbodenplatte = null,
     ) {
         $this->bausatzhaus = $bausatzhaus;
         $this->ausbauhaus = $ausbauhaus;

--- a/src/API/Ausblick.php
+++ b/src/API/Ausblick.php
@@ -24,7 +24,7 @@ class Ausblick
      * optional
      * @see BLICK_* constants
      */
-    protected string $blick = '';
+    public string $blick = '';
 
     public function getBlick(): ?string
     {

--- a/src/API/AusrichtBalkonTerrasse.php
+++ b/src/API/AusrichtBalkonTerrasse.php
@@ -20,7 +20,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("NORD")
      * optional
      */
-    protected ?bool $nord = null;
+    public ?bool $nord = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("OST")
      * optional
      */
-    protected ?bool $ost = null;
+    public ?bool $ost = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("SUED")
      * optional
      */
-    protected ?bool $sued = null;
+    public ?bool $sued = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("WEST")
      * optional
      */
-    protected ?bool $west = null;
+    public ?bool $west = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("NORDOST")
      * optional
      */
-    protected ?bool $nordost = null;
+    public ?bool $nordost = null;
 
     /**
      * @Type("bool")
@@ -60,7 +60,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("NORDWEST")
      * optional
      */
-    protected ?bool $nordwest = null;
+    public ?bool $nordwest = null;
 
     /**
      * @Type("bool")
@@ -68,7 +68,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("SUEDOST")
      * optional
      */
-    protected ?bool $suedost = null;
+    public ?bool $suedost = null;
 
     /**
      * @Type("bool")
@@ -76,7 +76,7 @@ class AusrichtBalkonTerrasse
      * @SerializedName("SUEDWEST")
      * optional
      */
-    protected ?bool $suedwest = null;
+    public ?bool $suedwest = null;
 
     public function getNord(): ?bool
     {

--- a/src/API/AussenCourtage.php
+++ b/src/API/AussenCourtage.php
@@ -19,13 +19,13 @@ class AussenCourtage
      * @XmlAttribute
      * optional
      */
-    protected ?bool $mitMwst = null;
+    public ?bool $mitMwst = null;
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getMitMwst(): ?bool
     {

--- a/src/API/Ausstattung.php
+++ b/src/API/Ausstattung.php
@@ -22,195 +22,195 @@ class Ausstattung
      * @Type("string")
      * @see AUSSTATT_KATEGORIE_* constants
      */
-    protected string $ausstattKategorie = '';
+    public string $ausstattKategorie = '';
 
     /** @Type("bool") */
-    protected ?bool $wgGeeignet = null;
+    public ?bool $wgGeeignet = null;
 
     /** @Type("bool") */
-    protected ?bool $raeumeVeraenderbar = null;
+    public ?bool $raeumeVeraenderbar = null;
 
     /** @Type("Ujamii\OpenImmo\API\Bad") */
-    protected ?Bad $bad = null;
+    public ?Bad $bad = null;
 
     /** @Type("Ujamii\OpenImmo\API\Kueche") */
-    protected ?Kueche $kueche = null;
+    public ?Kueche $kueche = null;
 
     /** @Type("Ujamii\OpenImmo\API\Boden") */
-    protected ?Boden $boden = null;
+    public ?Boden $boden = null;
 
     /** @Type("bool") */
-    protected ?bool $kamin = null;
+    public ?bool $kamin = null;
 
     /** @Type("Ujamii\OpenImmo\API\Heizungsart") */
-    protected ?Heizungsart $heizungsart = null;
+    public ?Heizungsart $heizungsart = null;
 
     /** @Type("Ujamii\OpenImmo\API\Befeuerung") */
-    protected ?Befeuerung $befeuerung = null;
+    public ?Befeuerung $befeuerung = null;
 
     /** @Type("bool") */
-    protected ?bool $klimatisiert = null;
+    public ?bool $klimatisiert = null;
 
     /** @Type("Ujamii\OpenImmo\API\Fahrstuhl") */
-    protected ?Fahrstuhl $fahrstuhl = null;
+    public ?Fahrstuhl $fahrstuhl = null;
 
     /**
      * @XmlList(inline = true, entry = "stellplatzart")
      * @Type("array<Ujamii\OpenImmo\API\Stellplatzart>")
      * @SkipWhenEmpty
      */
-    protected array $stellplatzart = [];
+    public array $stellplatzart = [];
 
     /** @Type("bool") */
-    protected ?bool $gartennutzung = null;
+    public ?bool $gartennutzung = null;
 
     /** @Type("Ujamii\OpenImmo\API\AusrichtBalkonTerrasse") */
-    protected ?AusrichtBalkonTerrasse $ausrichtBalkonTerrasse = null;
+    public ?AusrichtBalkonTerrasse $ausrichtBalkonTerrasse = null;
 
     /** @Type("Ujamii\OpenImmo\API\Moebliert") */
-    protected ?Moebliert $moebliert = null;
+    public ?Moebliert $moebliert = null;
 
     /** @Type("bool") */
-    protected ?bool $rollstuhlgerecht = null;
+    public ?bool $rollstuhlgerecht = null;
 
     /** @Type("bool") */
-    protected ?bool $kabelSatTv = null;
+    public ?bool $kabelSatTv = null;
 
     /** @Type("bool") */
-    protected ?bool $dvbt = null;
+    public ?bool $dvbt = null;
 
     /** @Type("bool") */
-    protected ?bool $barrierefrei = null;
+    public ?bool $barrierefrei = null;
 
     /** @Type("bool") */
-    protected ?bool $sauna = null;
+    public ?bool $sauna = null;
 
     /** @Type("bool") */
-    protected ?bool $swimmingpool = null;
+    public ?bool $swimmingpool = null;
 
     /** @Type("bool") */
-    protected ?bool $waschTrockenraum = null;
+    public ?bool $waschTrockenraum = null;
 
     /** @Type("bool") */
-    protected ?bool $wintergarten = null;
+    public ?bool $wintergarten = null;
 
     /** @Type("bool") */
-    protected ?bool $dvVerkabelung = null;
+    public ?bool $dvVerkabelung = null;
 
     /** @Type("bool") */
-    protected ?bool $rampe = null;
+    public ?bool $rampe = null;
 
     /** @Type("bool") */
-    protected ?bool $hebebuehne = null;
+    public ?bool $hebebuehne = null;
 
     /** @Type("bool") */
-    protected ?bool $kran = null;
+    public ?bool $kran = null;
 
     /** @Type("bool") */
-    protected ?bool $gastterrasse = null;
+    public ?bool $gastterrasse = null;
 
     /** @Type("string") */
-    protected ?string $stromanschlusswert = null;
+    public ?string $stromanschlusswert = null;
 
     /** @Type("bool") */
-    protected ?bool $kantineCafeteria = null;
+    public ?bool $kantineCafeteria = null;
 
     /** @Type("bool") */
-    protected ?bool $teekueche = null;
+    public ?bool $teekueche = null;
 
     /** @Type("float") */
-    protected ?float $hallenhoehe = null;
+    public ?float $hallenhoehe = null;
 
     /** @Type("Ujamii\OpenImmo\API\AngeschlGastronomie") */
-    protected ?AngeschlGastronomie $angeschlGastronomie = null;
+    public ?AngeschlGastronomie $angeschlGastronomie = null;
 
     /** @Type("bool") */
-    protected ?bool $brauereibindung = null;
+    public ?bool $brauereibindung = null;
 
     /** @Type("bool") */
-    protected ?bool $sporteinrichtungen = null;
+    public ?bool $sporteinrichtungen = null;
 
     /** @Type("bool") */
-    protected ?bool $wellnessbereich = null;
+    public ?bool $wellnessbereich = null;
 
     /**
      * @XmlList(inline = true, entry = "serviceleistungen")
      * @Type("array<Ujamii\OpenImmo\API\Serviceleistungen>")
      * @SkipWhenEmpty
      */
-    protected array $serviceleistungen = [];
+    public array $serviceleistungen = [];
 
     /** @Type("bool") */
-    protected ?bool $telefonFerienimmobilie = null;
+    public ?bool $telefonFerienimmobilie = null;
 
     /** @Type("Ujamii\OpenImmo\API\BreitbandZugang") */
-    protected ?BreitbandZugang $breitbandZugang = null;
+    public ?BreitbandZugang $breitbandZugang = null;
 
     /** @Type("bool") */
-    protected ?bool $umtsEmpfang = null;
+    public ?bool $umtsEmpfang = null;
 
     /** @Type("Ujamii\OpenImmo\API\Sicherheitstechnik") */
-    protected ?Sicherheitstechnik $sicherheitstechnik = null;
+    public ?Sicherheitstechnik $sicherheitstechnik = null;
 
     /** @Type("Ujamii\OpenImmo\API\Unterkellert") */
-    protected ?Unterkellert $unterkellert = null;
+    public ?Unterkellert $unterkellert = null;
 
     /** @Type("bool") */
-    protected ?bool $abstellraum = null;
+    public ?bool $abstellraum = null;
 
     /** @Type("bool") */
-    protected ?bool $fahrradraum = null;
+    public ?bool $fahrradraum = null;
 
     /** @Type("bool") */
-    protected ?bool $rolladen = null;
+    public ?bool $rolladen = null;
 
     /** @Type("Ujamii\OpenImmo\API\Dachform") */
-    protected ?Dachform $dachform = null;
+    public ?Dachform $dachform = null;
 
     /** @Type("Ujamii\OpenImmo\API\Bauweise") */
-    protected ?Bauweise $bauweise = null;
+    public ?Bauweise $bauweise = null;
 
     /** @Type("Ujamii\OpenImmo\API\Ausbaustufe") */
-    protected ?Ausbaustufe $ausbaustufe = null;
+    public ?Ausbaustufe $ausbaustufe = null;
 
     /** @Type("Ujamii\OpenImmo\API\Energietyp") */
-    protected ?Energietyp $energietyp = null;
+    public ?Energietyp $energietyp = null;
 
     /** @Type("bool") */
-    protected ?bool $bibliothek = null;
+    public ?bool $bibliothek = null;
 
     /** @Type("bool") */
-    protected ?bool $dachboden = null;
+    public ?bool $dachboden = null;
 
     /** @Type("bool") */
-    protected ?bool $gaestewc = null;
+    public ?bool $gaestewc = null;
 
     /** @Type("bool") */
-    protected ?bool $kabelkanaele = null;
+    public ?bool $kabelkanaele = null;
 
     /** @Type("bool") */
-    protected ?bool $seniorengerecht = null;
+    public ?bool $seniorengerecht = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getAusstattKategorie(): ?string
     {

--- a/src/API/Bad.php
+++ b/src/API/Bad.php
@@ -20,7 +20,7 @@ class Bad
      * @SerializedName("DUSCHE")
      * optional
      */
-    protected ?bool $dusche = null;
+    public ?bool $dusche = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Bad
      * @SerializedName("WANNE")
      * optional
      */
-    protected ?bool $wanne = null;
+    public ?bool $wanne = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Bad
      * @SerializedName("FENSTER")
      * optional
      */
-    protected ?bool $fenster = null;
+    public ?bool $fenster = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Bad
      * @SerializedName("BIDET")
      * optional
      */
-    protected ?bool $bidet = null;
+    public ?bool $bidet = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Bad
      * @SerializedName("PISSOIR")
      * optional
      */
-    protected ?bool $pissoir = null;
+    public ?bool $pissoir = null;
 
     public function getDusche(): ?bool
     {
@@ -114,7 +114,7 @@ class Bad
         ?bool $wanne = null,
         ?bool $fenster = null,
         ?bool $bidet = null,
-        ?bool $pissoir = null
+        ?bool $pissoir = null,
     ) {
         $this->dusche = $dusche;
         $this->wanne = $wanne;

--- a/src/API/Bauweise.php
+++ b/src/API/Bauweise.php
@@ -20,7 +20,7 @@ class Bauweise
      * @SerializedName("MASSIV")
      * optional
      */
-    protected ?bool $massiv = null;
+    public ?bool $massiv = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Bauweise
      * @SerializedName("FERTIGTEILE")
      * optional
      */
-    protected ?bool $fertigteile = null;
+    public ?bool $fertigteile = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Bauweise
      * @SerializedName("HOLZ")
      * optional
      */
-    protected ?bool $holz = null;
+    public ?bool $holz = null;
 
     public function getMassiv(): ?bool
     {

--- a/src/API/BebaubarNach.php
+++ b/src/API/BebaubarNach.php
@@ -27,7 +27,7 @@ class BebaubarNach
      * optional
      * @see BEBAUBAR_ATTR_* constants
      */
-    protected string $bebaubarAttr = '';
+    public string $bebaubarAttr = '';
 
     public function getBebaubarAttr(): ?string
     {

--- a/src/API/Befeuerung.php
+++ b/src/API/Befeuerung.php
@@ -20,7 +20,7 @@ class Befeuerung
      * @SerializedName("OEL")
      * optional
      */
-    protected ?bool $oel = null;
+    public ?bool $oel = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Befeuerung
      * @SerializedName("GAS")
      * optional
      */
-    protected ?bool $gas = null;
+    public ?bool $gas = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Befeuerung
      * @SerializedName("ELEKTRO")
      * optional
      */
-    protected ?bool $elektro = null;
+    public ?bool $elektro = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Befeuerung
      * @SerializedName("ALTERNATIV")
      * optional
      */
-    protected ?bool $alternativ = null;
+    public ?bool $alternativ = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Befeuerung
      * @SerializedName("SOLAR")
      * optional
      */
-    protected ?bool $solar = null;
+    public ?bool $solar = null;
 
     /**
      * @Type("bool")
@@ -60,7 +60,7 @@ class Befeuerung
      * @SerializedName("ERDWAERME")
      * optional
      */
-    protected ?bool $erdwaerme = null;
+    public ?bool $erdwaerme = null;
 
     /**
      * @Type("bool")
@@ -68,7 +68,7 @@ class Befeuerung
      * @SerializedName("LUFTWP")
      * optional
      */
-    protected ?bool $luftwp = null;
+    public ?bool $luftwp = null;
 
     /**
      * @Type("bool")
@@ -76,7 +76,7 @@ class Befeuerung
      * @SerializedName("FERN")
      * optional
      */
-    protected ?bool $fern = null;
+    public ?bool $fern = null;
 
     /**
      * @Type("bool")
@@ -84,7 +84,7 @@ class Befeuerung
      * @SerializedName("BLOCK")
      * optional
      */
-    protected ?bool $block = null;
+    public ?bool $block = null;
 
     /**
      * @Type("bool")
@@ -92,7 +92,7 @@ class Befeuerung
      * @SerializedName("WASSER-ELEKTRO")
      * optional
      */
-    protected ?bool $wasserElektro = null;
+    public ?bool $wasserElektro = null;
 
     /**
      * @Type("bool")
@@ -100,7 +100,7 @@ class Befeuerung
      * @SerializedName("PELLET")
      * optional
      */
-    protected ?bool $pellet = null;
+    public ?bool $pellet = null;
 
     /**
      * @Type("bool")
@@ -108,7 +108,7 @@ class Befeuerung
      * @SerializedName("KOHLE")
      * optional
      */
-    protected ?bool $kohle = null;
+    public ?bool $kohle = null;
 
     /**
      * @Type("bool")
@@ -116,7 +116,7 @@ class Befeuerung
      * @SerializedName("HOLZ")
      * optional
      */
-    protected ?bool $holz = null;
+    public ?bool $holz = null;
 
     /**
      * @Type("bool")
@@ -124,7 +124,7 @@ class Befeuerung
      * @SerializedName("FLUESSIGGAS")
      * optional
      */
-    protected ?bool $fluessiggas = null;
+    public ?bool $fluessiggas = null;
 
     public function getOel(): ?bool
     {

--- a/src/API/Betriebskostennetto.php
+++ b/src/API/Betriebskostennetto.php
@@ -19,13 +19,13 @@ class Betriebskostennetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $betriebskostenust = null;
+    public ?float $betriebskostenust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getBetriebskostenust(): ?float
     {

--- a/src/API/Bewertung.php
+++ b/src/API/Bewertung.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Bewertung
- * Container für detailierte Bewertungs Parmater
+ * Container fÃ¼r detailierte Bewertungs Parmater
  * @XmlRoot("bewertung")
  */
 class Bewertung
@@ -19,7 +19,7 @@ class Bewertung
      * @Type("array<Ujamii\OpenImmo\API\Feld>")
      * @SkipWhenEmpty
      */
-    protected array $feld = [];
+    public array $feld = [];
 
     /**
      * Returns array of array

--- a/src/API/Bieterverfahren.php
+++ b/src/API/Bieterverfahren.php
@@ -15,46 +15,46 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Bieterverfahren
 {
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $beginnAngebotsphase = null;
+    public ?\DateTime $beginnAngebotsphase = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $besichtigungstermin = null;
+    public ?\DateTime $besichtigungstermin = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $besichtigungstermin2 = null;
+    public ?\DateTime $besichtigungstermin2 = null;
 
     /** @Type("DateTime<'Y-m-d\TH:i:s', null, ['Y-m-d\TH:i:sP', 'Y-m-d\TH:i:s']>") */
-    protected ?\DateTime $beginnBietzeit = null;
+    public ?\DateTime $beginnBietzeit = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $endeBietzeit = null;
+    public ?\DateTime $endeBietzeit = null;
 
     /** @Type("bool") */
-    protected ?bool $hoechstgebotZeigen = null;
+    public ?bool $hoechstgebotZeigen = null;
 
     /** @Type("float") */
-    protected ?float $mindestpreis = null;
+    public ?float $mindestpreis = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getBeginnAngebotsphase(): ?\DateTime
     {

--- a/src/API/Boden.php
+++ b/src/API/Boden.php
@@ -20,7 +20,7 @@ class Boden
      * @SerializedName("FLIESEN")
      * optional
      */
-    protected ?bool $fliesen = null;
+    public ?bool $fliesen = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Boden
      * @SerializedName("STEIN")
      * optional
      */
-    protected ?bool $stein = null;
+    public ?bool $stein = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Boden
      * @SerializedName("TEPPICH")
      * optional
      */
-    protected ?bool $teppich = null;
+    public ?bool $teppich = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Boden
      * @SerializedName("PARKETT")
      * optional
      */
-    protected ?bool $parkett = null;
+    public ?bool $parkett = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Boden
      * @SerializedName("FERTIGPARKETT")
      * optional
      */
-    protected ?bool $fertigparkett = null;
+    public ?bool $fertigparkett = null;
 
     /**
      * @Type("bool")
@@ -60,7 +60,7 @@ class Boden
      * @SerializedName("LAMINAT")
      * optional
      */
-    protected ?bool $laminat = null;
+    public ?bool $laminat = null;
 
     /**
      * @Type("bool")
@@ -68,7 +68,7 @@ class Boden
      * @SerializedName("DIELEN")
      * optional
      */
-    protected ?bool $dielen = null;
+    public ?bool $dielen = null;
 
     /**
      * @Type("bool")
@@ -76,7 +76,7 @@ class Boden
      * @SerializedName("KUNSTSTOFF")
      * optional
      */
-    protected ?bool $kunststoff = null;
+    public ?bool $kunststoff = null;
 
     /**
      * @Type("bool")
@@ -84,7 +84,7 @@ class Boden
      * @SerializedName("ESTRICH")
      * optional
      */
-    protected ?bool $estrich = null;
+    public ?bool $estrich = null;
 
     /**
      * @Type("bool")
@@ -92,7 +92,7 @@ class Boden
      * @SerializedName("DOPPELBODEN")
      * optional
      */
-    protected ?bool $doppelboden = null;
+    public ?bool $doppelboden = null;
 
     /**
      * @Type("bool")
@@ -100,7 +100,7 @@ class Boden
      * @SerializedName("LINOLEUM")
      * optional
      */
-    protected ?bool $linoleum = null;
+    public ?bool $linoleum = null;
 
     /**
      * @Type("bool")
@@ -108,7 +108,7 @@ class Boden
      * @SerializedName("MARMOR")
      * optional
      */
-    protected ?bool $marmor = null;
+    public ?bool $marmor = null;
 
     /**
      * @Type("bool")
@@ -116,7 +116,7 @@ class Boden
      * @SerializedName("TERRAKOTTA")
      * optional
      */
-    protected ?bool $terrakotta = null;
+    public ?bool $terrakotta = null;
 
     /**
      * @Type("bool")
@@ -124,7 +124,7 @@ class Boden
      * @SerializedName("GRANIT")
      * optional
      */
-    protected ?bool $granit = null;
+    public ?bool $granit = null;
 
     public function getFliesen(): ?bool
     {

--- a/src/API/BreitbandZugang.php
+++ b/src/API/BreitbandZugang.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class BreitbandZugang
- * Informationen über die Breitbandmöglichkeiten.
+ * Informationen Ã¼ber die BreitbandmÃ¶glichkeiten.
  * @XmlRoot("breitband_zugang")
  */
 class BreitbandZugang
@@ -18,14 +18,14 @@ class BreitbandZugang
      * @XmlAttribute
      * optional
      */
-    protected ?string $art = null;
+    public ?string $art = null;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * optional
      */
-    protected ?float $speed = null;
+    public ?float $speed = null;
 
     public function getArt(): ?string
     {

--- a/src/API/BueroPraxen.php
+++ b/src/API/BueroPraxen.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class BueroPraxen
- * Objektart / Typ f. Büro/Praxen
+ * Objektart / Typ f. BÃ¼ro/Praxen
  * @XmlRoot("buero_praxen")
  */
 class BueroPraxen
@@ -30,7 +30,7 @@ class BueroPraxen
      * optional
      * @see BUERO_TYP_* constants
      */
-    protected string $bueroTyp = '';
+    public string $bueroTyp = '';
 
     public function getBueroTyp(): ?string
     {

--- a/src/API/Check.php
+++ b/src/API/Check.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Check
- * Angabe von Daten für die Prüfung auf ein Update
+ * Angabe von Daten fÃ¼r die PrÃ¼fung auf ein Update
  * @XmlRoot("check")
  */
 class Check
@@ -24,13 +24,13 @@ class Check
      * required
      * @see CTYPE_* constants
      */
-    protected string $ctype = '';
+    public string $ctype = '';
 
     /**
      * @Inline
      * @Type("DateTime<'Y-m-d\TH:i:s', null, ['Y-m-d\TH:i:sP', 'Y-m-d\TH:i:s']>")
      */
-    protected ?\DateTime $value = null;
+    public ?\DateTime $value = null;
 
     public function getCtype(): string
     {

--- a/src/API/Dachform.php
+++ b/src/API/Dachform.php
@@ -20,7 +20,7 @@ class Dachform
      * @SerializedName("KRUEPPELWALMDACH")
      * optional
      */
-    protected ?bool $krueppelwalmdach = null;
+    public ?bool $krueppelwalmdach = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Dachform
      * @SerializedName("MANSARDDACH")
      * optional
      */
-    protected ?bool $mansarddach = null;
+    public ?bool $mansarddach = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Dachform
      * @SerializedName("PULTDACH")
      * optional
      */
-    protected ?bool $pultdach = null;
+    public ?bool $pultdach = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Dachform
      * @SerializedName("SATTELDACH")
      * optional
      */
-    protected ?bool $satteldach = null;
+    public ?bool $satteldach = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Dachform
      * @SerializedName("WALMDACH")
      * optional
      */
-    protected ?bool $walmdach = null;
+    public ?bool $walmdach = null;
 
     /**
      * @Type("bool")
@@ -60,7 +60,7 @@ class Dachform
      * @SerializedName("FLACHDACH")
      * optional
      */
-    protected ?bool $flachdach = null;
+    public ?bool $flachdach = null;
 
     /**
      * @Type("bool")
@@ -68,7 +68,7 @@ class Dachform
      * @SerializedName("PYRAMIDENDACH")
      * optional
      */
-    protected ?bool $pyramidendach = null;
+    public ?bool $pyramidendach = null;
 
     public function getKrueppelwalmdach(): ?bool
     {

--- a/src/API/Daten.php
+++ b/src/API/Daten.php
@@ -13,10 +13,10 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Daten
 {
     /** @Type("string") */
-    protected ?string $pfad = null;
+    public ?string $pfad = null;
 
     /** @Type("string") */
-    protected ?string $anhanginhalt = null;
+    public ?string $anhanginhalt = null;
 
     public function getPfad(): ?string
     {

--- a/src/API/Distanzen.php
+++ b/src/API/Distanzen.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Distanzen
- * Welche Distanz zu dem ausgewählten Ziel besteht (Angabe in km),
+ * Welche Distanz zu dem ausgewÃ¤hlten Ziel besteht (Angabe in km),
  *  Optionen nicht kombinierbar, Distanzelement ist mehrfach erfassbar
  * @XmlRoot("distanzen")
  */
@@ -36,13 +36,13 @@ class Distanzen
      * required
      * @see DISTANZ_ZU_* constants
      */
-    protected string $distanzZu = '';
+    public string $distanzZu = '';
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getDistanzZu(): string
     {

--- a/src/API/DistanzenSport.php
+++ b/src/API/DistanzenSport.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class DistanzenSport
- * Welche Distanz zu dem ausgewählen Sport-/Freizeitziel besteht(Angabe in km),
+ * Welche Distanz zu dem ausgewÃ¤hlen Sport-/Freizeitziel besteht(Angabe in km),
  *  Optionen nicht kombinierbar, Distanzelement ist mehrfach erfassbar
  * @XmlRoot("distanzen_sport")
  */
@@ -29,13 +29,13 @@ class DistanzenSport
      * required
      * @see DISTANZ_ZU_SPORT_* constants
      */
-    protected string $distanzZuSport = '';
+    public string $distanzZuSport = '';
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getDistanzZuSport(): string
     {

--- a/src/API/Einzelhandel.php
+++ b/src/API/Einzelhandel.php
@@ -29,7 +29,7 @@ class Einzelhandel
      * optional
      * @see HANDEL_TYP_* constants
      */
-    protected string $handelTyp = '';
+    public string $handelTyp = '';
 
     public function getHandelTyp(): ?string
     {

--- a/src/API/EmailSonstige.php
+++ b/src/API/EmailSonstige.php
@@ -25,20 +25,20 @@ class EmailSonstige
      * optional
      * @see EMAILART_* constants
      */
-    protected string $emailart = '';
+    public string $emailart = '';
 
     /**
      * @Type("string")
      * @XmlAttribute
      * optional
      */
-    protected ?string $bemerkung = null;
+    public ?string $bemerkung = null;
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getEmailart(): ?string
     {

--- a/src/API/Energiepass.php
+++ b/src/API/Energiepass.php
@@ -26,67 +26,67 @@ class Energiepass
      * @Type("string")
      * @see EPART_* constants
      */
-    protected string $epart = '';
+    public string $epart = '';
 
     /** @Type("string") */
-    protected ?string $gueltigBis = null;
+    public ?string $gueltigBis = null;
 
     /** @Type("string") */
-    protected ?string $energieverbrauchkennwert = null;
+    public ?string $energieverbrauchkennwert = null;
 
     /** @Type("bool") */
-    protected ?bool $mitwarmwasser = null;
+    public ?bool $mitwarmwasser = null;
 
     /** @Type("string") */
-    protected ?string $endenergiebedarf = null;
+    public ?string $endenergiebedarf = null;
 
     /** @Type("string") */
-    protected ?string $primaerenergietraeger = null;
+    public ?string $primaerenergietraeger = null;
 
     /** @Type("string") */
-    protected ?string $stromwert = null;
+    public ?string $stromwert = null;
 
     /** @Type("string") */
-    protected ?string $waermewert = null;
+    public ?string $waermewert = null;
 
     /** @Type("string") */
-    protected ?string $wertklasse = null;
+    public ?string $wertklasse = null;
 
     /** @Type("string") */
-    protected ?string $baujahr = null;
+    public ?string $baujahr = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $ausstelldatum = null;
+    public ?\DateTime $ausstelldatum = null;
 
     /**
      * @Type("string")
      * @see JAHRGANG_* constants
      */
-    protected string $jahrgang = '';
+    public string $jahrgang = '';
 
     /**
      * @Type("string")
      * @see GEBAEUDEART_* constants
      */
-    protected string $gebaeudeart = '';
+    public string $gebaeudeart = '';
 
     /** @Type("string") */
-    protected ?string $epasstext = null;
+    public ?string $epasstext = null;
 
     /** @Type("string") */
-    protected ?string $geg2018 = null;
+    public ?string $geg2018 = null;
 
     /** @Type("string") */
-    protected ?string $hwbwert = null;
+    public ?string $hwbwert = null;
 
     /** @Type("string") */
-    protected ?string $hwbklasse = null;
+    public ?string $hwbklasse = null;
 
     /** @Type("string") */
-    protected ?string $fgeewert = null;
+    public ?string $fgeewert = null;
 
     /** @Type("string") */
-    protected ?string $fgeeklasse = null;
+    public ?string $fgeeklasse = null;
 
     public function getEpart(): ?string
     {

--- a/src/API/Energietyp.php
+++ b/src/API/Energietyp.php
@@ -20,7 +20,7 @@ class Energietyp
      * @SerializedName("PASSIVHAUS")
      * optional
      */
-    protected ?bool $passivhaus = null;
+    public ?bool $passivhaus = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Energietyp
      * @SerializedName("NIEDRIGENERGIE")
      * optional
      */
-    protected ?bool $niedrigenergie = null;
+    public ?bool $niedrigenergie = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Energietyp
      * @SerializedName("NEUBAUSTANDARD")
      * optional
      */
-    protected ?bool $neubaustandard = null;
+    public ?bool $neubaustandard = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Energietyp
      * @SerializedName("KFW40")
      * optional
      */
-    protected ?bool $kfw40 = null;
+    public ?bool $kfw40 = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Energietyp
      * @SerializedName("KFW60")
      * optional
      */
-    protected ?bool $kfw60 = null;
+    public ?bool $kfw60 = null;
 
     /**
      * @Type("bool")
@@ -60,7 +60,7 @@ class Energietyp
      * @SerializedName("KFW55")
      * optional
      */
-    protected ?bool $kfw55 = null;
+    public ?bool $kfw55 = null;
 
     /**
      * @Type("bool")
@@ -68,7 +68,7 @@ class Energietyp
      * @SerializedName("KFW70")
      * optional
      */
-    protected ?bool $kfw70 = null;
+    public ?bool $kfw70 = null;
 
     /**
      * @Type("bool")
@@ -76,7 +76,7 @@ class Energietyp
      * @SerializedName("MINERGIEBAUWEISE")
      * optional
      */
-    protected ?bool $minergiebauweise = null;
+    public ?bool $minergiebauweise = null;
 
     /**
      * @Type("bool")
@@ -84,7 +84,7 @@ class Energietyp
      * @SerializedName("MINERGIE_ZERTIFIZIERT")
      * optional
      */
-    protected ?bool $minergieZertifiziert = null;
+    public ?bool $minergieZertifiziert = null;
 
     public function getPassivhaus(): ?bool
     {

--- a/src/API/Erschliessung.php
+++ b/src/API/Erschliessung.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Erschliessung
- * Stand der Erschließung, Optionen nicht kombinierbar
+ * Stand der ErschlieÃung, Optionen nicht kombinierbar
  * @XmlRoot("erschliessung")
  */
 class Erschliessung
@@ -24,7 +24,7 @@ class Erschliessung
      * optional
      * @see ERSCHL_ATTR_* constants
      */
-    protected string $erschlAttr = '';
+    public string $erschlAttr = '';
 
     public function getErschlAttr(): ?string
     {

--- a/src/API/ErschliessungUmfang.php
+++ b/src/API/ErschliessungUmfang.php
@@ -24,7 +24,7 @@ class ErschliessungUmfang
      * optional
      * @see ERSCHL_ATTR_* constants
      */
-    protected string $erschlAttr = '';
+    public string $erschlAttr = '';
 
     public function getErschlAttr(): ?string
     {

--- a/src/API/Evbnetto.php
+++ b/src/API/Evbnetto.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Evbnetto
- * Erhaltungs- und Verbesserungsbeitrag. Ähnlich Instanthaltungsrücklage, UmSt. im Attribut.
+ * Erhaltungs- und Verbesserungsbeitrag. Ãhnlich InstanthaltungsrÃ¼cklage, UmSt. im Attribut.
  * @XmlRoot("evbnetto")
  */
 class Evbnetto
@@ -19,13 +19,13 @@ class Evbnetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $evbust = null;
+    public ?float $evbust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getEvbust(): ?float
     {

--- a/src/API/Fahrstuhl.php
+++ b/src/API/Fahrstuhl.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Fahrstuhl
- * Welche Art von Fahrstuhl, Aufzug, Lift - Mehrfachnennung möglich
+ * Welche Art von Fahrstuhl, Aufzug, Lift - Mehrfachnennung mÃ¶glich
  * @XmlRoot("fahrstuhl")
  */
 class Fahrstuhl
@@ -20,7 +20,7 @@ class Fahrstuhl
      * @SerializedName("PERSONEN")
      * optional
      */
-    protected ?bool $personen = null;
+    public ?bool $personen = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Fahrstuhl
      * @SerializedName("LASTEN")
      * optional
      */
-    protected ?bool $lasten = null;
+    public ?bool $lasten = null;
 
     public function getPersonen(): ?bool
     {

--- a/src/API/Feld.php
+++ b/src/API/Feld.php
@@ -18,27 +18,27 @@ class Feld
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $name = '';
+    public string $name = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $wert = '';
+    public string $wert = '';
 
     /**
      * @XmlList(inline = true, entry = "typ")
      * @Type("array<string>")
      * @SkipWhenEmpty
      */
-    protected array $typ = [];
+    public array $typ = [];
 
     /**
      * @XmlList(inline = true, entry = "modus")
      * @Type("array<string>")
      * @SkipWhenEmpty
      */
-    protected array $modus = [];
+    public array $modus = [];
 
     public function getName(): string
     {

--- a/src/API/Flaechen.php
+++ b/src/API/Flaechen.php
@@ -15,166 +15,166 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Flaechen
 {
     /** @Type("float") */
-    protected ?float $wohnflaeche = null;
+    public ?float $wohnflaeche = null;
 
     /** @Type("float") */
-    protected ?float $nutzflaeche = null;
+    public ?float $nutzflaeche = null;
 
     /** @Type("float") */
-    protected ?float $gesamtflaeche = null;
+    public ?float $gesamtflaeche = null;
 
     /** @Type("float") */
-    protected ?float $ladenflaeche = null;
+    public ?float $ladenflaeche = null;
 
     /** @Type("float") */
-    protected ?float $lagerflaeche = null;
+    public ?float $lagerflaeche = null;
 
     /** @Type("float") */
-    protected ?float $verkaufsflaeche = null;
+    public ?float $verkaufsflaeche = null;
 
     /** @Type("float") */
-    protected ?float $freiflaeche = null;
+    public ?float $freiflaeche = null;
 
     /** @Type("float") */
-    protected ?float $bueroflaeche = null;
+    public ?float $bueroflaeche = null;
 
     /** @Type("float") */
-    protected ?float $bueroteilflaeche = null;
+    public ?float $bueroteilflaeche = null;
 
     /** @Type("float") */
-    protected ?float $fensterfront = null;
+    public ?float $fensterfront = null;
 
     /** @Type("float") */
-    protected ?float $verwaltungsflaeche = null;
+    public ?float $verwaltungsflaeche = null;
 
     /** @Type("float") */
-    protected ?float $gastroflaeche = null;
+    public ?float $gastroflaeche = null;
 
     /** @Type("string") */
-    protected ?string $grz = null;
+    public ?string $grz = null;
 
     /** @Type("string") */
-    protected ?string $gfz = null;
+    public ?string $gfz = null;
 
     /** @Type("string") */
-    protected ?string $bmz = null;
+    public ?string $bmz = null;
 
     /** @Type("string") */
-    protected ?string $bgf = null;
+    public ?string $bgf = null;
 
     /** @Type("float") */
-    protected ?float $grundstuecksflaeche = null;
+    public ?float $grundstuecksflaeche = null;
 
     /** @Type("float") */
-    protected ?float $sonstflaeche = null;
+    public ?float $sonstflaeche = null;
 
     /** @Type("float") */
-    protected ?float $anzahlZimmer = null;
+    public ?float $anzahlZimmer = null;
 
     /** @Type("float") */
-    protected ?float $anzahlSchlafzimmer = null;
+    public ?float $anzahlSchlafzimmer = null;
 
     /** @Type("float") */
-    protected ?float $anzahlBadezimmer = null;
+    public ?float $anzahlBadezimmer = null;
 
     /** @Type("float") */
-    protected ?float $anzahlSepWc = null;
+    public ?float $anzahlSepWc = null;
 
     /** @Type("float") */
-    protected ?float $anzahlBalkone = null;
+    public ?float $anzahlBalkone = null;
 
     /** @Type("float") */
-    protected ?float $anzahlTerrassen = null;
+    public ?float $anzahlTerrassen = null;
 
     /** @Type("float") */
-    protected ?float $anzahlLogia = null;
+    public ?float $anzahlLogia = null;
 
     /** @Type("float") */
-    protected ?float $balkonTerrasseFlaeche = null;
+    public ?float $balkonTerrasseFlaeche = null;
 
     /** @Type("float") */
-    protected ?float $anzahlWohnSchlafzimmer = null;
+    public ?float $anzahlWohnSchlafzimmer = null;
 
     /** @Type("float") */
-    protected ?float $gartenflaeche = null;
+    public ?float $gartenflaeche = null;
 
     /** @Type("float") */
-    protected ?float $kellerflaeche = null;
+    public ?float $kellerflaeche = null;
 
     /** @Type("float") */
-    protected ?float $fensterfrontQm = null;
+    public ?float $fensterfrontQm = null;
 
     /** @Type("float") */
-    protected ?float $grundstuecksfront = null;
+    public ?float $grundstuecksfront = null;
 
     /** @Type("float") */
-    protected ?float $dachbodenflaeche = null;
+    public ?float $dachbodenflaeche = null;
 
     /** @Type("float") */
-    protected ?float $teilbarAb = null;
+    public ?float $teilbarAb = null;
 
     /** @Type("float") */
-    protected ?float $beheizbareFlaeche = null;
+    public ?float $beheizbareFlaeche = null;
 
     /**
      * @Type("int")
      * Minimum value (inclusive): 1
      */
-    protected ?int $anzahlStellplaetze = null;
+    public ?int $anzahlStellplaetze = null;
 
     /** @Type("float") */
-    protected ?float $plaetzeGastraum = null;
+    public ?float $plaetzeGastraum = null;
 
     /** @Type("float") */
-    protected ?float $anzahlBetten = null;
+    public ?float $anzahlBetten = null;
 
     /** @Type("float") */
-    protected ?float $anzahlTagungsraeume = null;
+    public ?float $anzahlTagungsraeume = null;
 
     /** @Type("float") */
-    protected ?float $vermietbareFlaeche = null;
+    public ?float $vermietbareFlaeche = null;
 
     /** @Type("float") */
-    protected ?float $anzahlWohneinheiten = null;
+    public ?float $anzahlWohneinheiten = null;
 
     /** @Type("float") */
-    protected ?float $anzahlGewerbeeinheiten = null;
+    public ?float $anzahlGewerbeeinheiten = null;
 
     /** @Type("bool") */
-    protected ?bool $einliegerwohnung = null;
+    public ?bool $einliegerwohnung = null;
 
     /** @Type("float") */
-    protected ?float $kubatur = null;
+    public ?float $kubatur = null;
 
     /** @Type("float") */
-    protected ?float $ausnuetzungsziffer = null;
+    public ?float $ausnuetzungsziffer = null;
 
     /** @Type("float") */
-    protected ?float $flaechevon = null;
+    public ?float $flaechevon = null;
 
     /** @Type("float") */
-    protected ?float $flaechebis = null;
+    public ?float $flaechebis = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getWohnflaeche(): ?float
     {

--- a/src/API/Foto.php
+++ b/src/API/Foto.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Foto
- * Foto bei der Kontaktperson. Datentyp ähnlich "Anhang"
+ * Foto bei der Kontaktperson. Datentyp Ã¤hnlich "Anhang"
  * foto from the kontakt person of the sender
  * @XmlRoot("foto")
  */
@@ -24,16 +24,16 @@ class Foto
      * required
      * @see LOCATION_* constants
      */
-    protected string $location = '';
+    public string $location = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $format = '';
+    public string $format = '';
 
     /** @Type("Ujamii\OpenImmo\API\Daten") */
-    protected ?Daten $daten = null;
+    public ?Daten $daten = null;
 
     public function getLocation(): string
     {

--- a/src/API/Freitexte.php
+++ b/src/API/Freitexte.php
@@ -15,46 +15,46 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Freitexte
 {
     /** @Type("string") */
-    protected ?string $objekttitel = null;
+    public ?string $objekttitel = null;
 
     /** @Type("string") */
-    protected ?string $dreizeiler = null;
+    public ?string $dreizeiler = null;
 
     /** @Type("string") */
-    protected ?string $lage = null;
+    public ?string $lage = null;
 
     /** @Type("string") */
-    protected ?string $ausstattBeschr = null;
+    public ?string $ausstattBeschr = null;
 
     /** @Type("string") */
-    protected ?string $objektbeschreibung = null;
+    public ?string $objektbeschreibung = null;
 
     /** @Type("string") */
-    protected ?string $sonstigeAngaben = null;
+    public ?string $sonstigeAngaben = null;
 
     /** @Type("Ujamii\OpenImmo\API\ObjektText") */
-    protected ?ObjektText $objektText = null;
+    public ?ObjektText $objektText = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getObjekttitel(): ?string
     {

--- a/src/API/FreizeitimmobilieGewerblich.php
+++ b/src/API/FreizeitimmobilieGewerblich.php
@@ -23,7 +23,7 @@ class FreizeitimmobilieGewerblich
      * optional
      * @see FREIZEIT_TYP_* constants
      */
-    protected string $freizeitTyp = '';
+    public string $freizeitTyp = '';
 
     public function getFreizeitTyp(): ?string
     {

--- a/src/API/Gastgewerbe.php
+++ b/src/API/Gastgewerbe.php
@@ -31,7 +31,7 @@ class Gastgewerbe
      * optional
      * @see GASTGEW_TYP_* constants
      */
-    protected string $gastgewTyp = '';
+    public string $gastgewTyp = '';
 
     public function getGastgewTyp(): ?string
     {

--- a/src/API/Geo.php
+++ b/src/API/Geo.php
@@ -15,96 +15,96 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Geo
 {
     /** @Type("string") */
-    protected ?string $plz = null;
+    public ?string $plz = null;
 
     /** @Type("string") */
-    protected ?string $ort = null;
+    public ?string $ort = null;
 
     /** @Type("Ujamii\OpenImmo\API\Geokoordinaten") */
-    protected ?Geokoordinaten $geokoordinaten = null;
+    public ?Geokoordinaten $geokoordinaten = null;
 
     /** @Type("string") */
-    protected ?string $strasse = null;
+    public ?string $strasse = null;
 
     /** @Type("string") */
-    protected ?string $hausnummer = null;
+    public ?string $hausnummer = null;
 
     /** @Type("string") */
-    protected ?string $bundesland = null;
+    public ?string $bundesland = null;
 
     /** @Type("Ujamii\OpenImmo\API\Land") */
-    protected ?Land $land = null;
+    public ?Land $land = null;
 
     /** @Type("string") */
-    protected ?string $gemeindecode = null;
+    public ?string $gemeindecode = null;
 
     /** @Type("string") */
-    protected ?string $flur = null;
+    public ?string $flur = null;
 
     /** @Type("string") */
-    protected ?string $flurstueck = null;
+    public ?string $flurstueck = null;
 
     /** @Type("string") */
-    protected ?string $gemarkung = null;
+    public ?string $gemarkung = null;
 
     /**
      * @Type("int")
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $etage = null;
+    public ?int $etage = null;
 
     /**
      * @Type("int")
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $anzahlEtagen = null;
+    public ?int $anzahlEtagen = null;
 
     /** @Type("Ujamii\OpenImmo\API\LageImBau") */
-    protected ?LageImBau $lageImBau = null;
+    public ?LageImBau $lageImBau = null;
 
     /** @Type("string") */
-    protected ?string $wohnungsnr = null;
+    public ?string $wohnungsnr = null;
 
     /** @Type("Ujamii\OpenImmo\API\LageGebiet") */
-    protected ?LageGebiet $lageGebiet = null;
+    public ?LageGebiet $lageGebiet = null;
 
     /** @Type("string") */
-    protected ?string $regionalerZusatz = null;
+    public ?string $regionalerZusatz = null;
 
     /** @Type("bool") */
-    protected ?bool $kartenMakro = null;
+    public ?bool $kartenMakro = null;
 
     /** @Type("bool") */
-    protected ?bool $kartenMikro = null;
+    public ?bool $kartenMikro = null;
 
     /** @Type("bool") */
-    protected ?bool $virtuelletour = null;
+    public ?bool $virtuelletour = null;
 
     /** @Type("bool") */
-    protected ?bool $luftbildern = null;
+    public ?bool $luftbildern = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getPlz(): ?string
     {

--- a/src/API/Geokoordinaten.php
+++ b/src/API/Geokoordinaten.php
@@ -18,14 +18,14 @@ class Geokoordinaten
      * @XmlAttribute
      * required
      */
-    protected float $breitengrad = 0.0;
+    public float $breitengrad = 0.0;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * required
      */
-    protected float $laengengrad = 0.0;
+    public float $laengengrad = 0.0;
 
     public function getBreitengrad(): float
     {

--- a/src/API/Gesamtbelastungnetto.php
+++ b/src/API/Gesamtbelastungnetto.php
@@ -19,13 +19,13 @@ class Gesamtbelastungnetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $gesamtbelastungust = null;
+    public ?float $gesamtbelastungust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getGesamtbelastungust(): ?float
     {

--- a/src/API/Gesamtkostenprom2von.php
+++ b/src/API/Gesamtkostenprom2von.php
@@ -19,13 +19,13 @@ class Gesamtkostenprom2von
      * @XmlAttribute
      * optional
      */
-    protected ?float $gesamtkostenprom2bis = null;
+    public ?float $gesamtkostenprom2bis = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getGesamtkostenprom2bis(): ?float
     {

--- a/src/API/Gesamtmietenetto.php
+++ b/src/API/Gesamtmietenetto.php
@@ -19,13 +19,13 @@ class Gesamtmietenetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $gesamtmieteust = null;
+    public ?float $gesamtmieteust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getGesamtmieteust(): ?float
     {

--- a/src/API/Geschlecht.php
+++ b/src/API/Geschlecht.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Geschlecht
- * Soll das Objekt nur an Frauen bzw. nur an Männer vermietet werden,
+ * Soll das Objekt nur an Frauen bzw. nur an MÃ¤nner vermietet werden,
  *  fehlende Angabe wird als 'Ja' interpretiert
  * @XmlRoot("geschlecht")
  */
@@ -24,7 +24,7 @@ class Geschlecht
      * optional
      * @see GESCHL_ATTR_* constants
      */
-    protected string $geschlAttr = '';
+    public string $geschlAttr = '';
 
     public function getGeschlAttr(): ?string
     {

--- a/src/API/Grundstueck.php
+++ b/src/API/Grundstueck.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Grundstueck
- * Objektart / Typ f. Grundstücke
+ * Objektart / Typ f. GrundstÃ¼cke
  * @XmlRoot("grundstueck")
  */
 class Grundstueck
@@ -29,7 +29,7 @@ class Grundstueck
      * optional
      * @see GRUNDST_TYP_* constants
      */
-    protected string $grundstTyp = '';
+    public string $grundstTyp = '';
 
     public function getGrundstTyp(): ?string
     {

--- a/src/API/HallenLagerProd.php
+++ b/src/API/HallenLagerProd.php
@@ -32,7 +32,7 @@ class HallenLagerProd
      * optional
      * @see HALLEN_TYP_* constants
      */
-    protected string $hallenTyp = '';
+    public string $hallenTyp = '';
 
     public function getHallenTyp(): ?string
     {

--- a/src/API/Hauptmietzinsnetto.php
+++ b/src/API/Hauptmietzinsnetto.php
@@ -19,13 +19,13 @@ class Hauptmietzinsnetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $hauptmietzinsust = null;
+    public ?float $hauptmietzinsust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getHauptmietzinsust(): ?float
     {

--- a/src/API/Haus.php
+++ b/src/API/Haus.php
@@ -47,7 +47,7 @@ class Haus
      * optional
      * @see HAUSTYP_* constants
      */
-    protected string $haustyp = '';
+    public string $haustyp = '';
 
     public function getHaustyp(): ?string
     {

--- a/src/API/Heizkostennetto.php
+++ b/src/API/Heizkostennetto.php
@@ -19,13 +19,13 @@ class Heizkostennetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $heizkostenust = null;
+    public ?float $heizkostenust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getHeizkostenust(): ?float
     {

--- a/src/API/Heizungsart.php
+++ b/src/API/Heizungsart.php
@@ -20,7 +20,7 @@ class Heizungsart
      * @SerializedName("OFEN")
      * optional
      */
-    protected ?bool $ofen = null;
+    public ?bool $ofen = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Heizungsart
      * @SerializedName("ETAGE")
      * optional
      */
-    protected ?bool $etage = null;
+    public ?bool $etage = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Heizungsart
      * @SerializedName("ZENTRAL")
      * optional
      */
-    protected ?bool $zentral = null;
+    public ?bool $zentral = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Heizungsart
      * @SerializedName("FERN")
      * optional
      */
-    protected ?bool $fern = null;
+    public ?bool $fern = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Heizungsart
      * @SerializedName("FUSSBODEN")
      * optional
      */
-    protected ?bool $fussboden = null;
+    public ?bool $fussboden = null;
 
     public function getOfen(): ?bool
     {
@@ -114,7 +114,7 @@ class Heizungsart
         ?bool $etage = null,
         ?bool $zentral = null,
         ?bool $fern = null,
-        ?bool $fussboden = null
+        ?bool $fussboden = null,
     ) {
         $this->ofen = $ofen;
         $this->etage = $etage;

--- a/src/API/Immobilie.php
+++ b/src/API/Immobilie.php
@@ -15,77 +15,77 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Immobilie
 {
     /** @Type("Ujamii\OpenImmo\API\Objektkategorie") */
-    protected ?Objektkategorie $objektkategorie = null;
+    public ?Objektkategorie $objektkategorie = null;
 
     /** @Type("Ujamii\OpenImmo\API\Geo") */
-    protected ?Geo $geo = null;
+    public ?Geo $geo = null;
 
     /** @Type("Ujamii\OpenImmo\API\Kontaktperson") */
-    protected ?Kontaktperson $kontaktperson = null;
+    public ?Kontaktperson $kontaktperson = null;
 
     /**
      * @XmlList(inline = true, entry = "weitere_adresse")
      * @Type("array<Ujamii\OpenImmo\API\WeitereAdresse>")
      * @SkipWhenEmpty
      */
-    protected array $weitereAdresse = [];
+    public array $weitereAdresse = [];
 
     /** @Type("Ujamii\OpenImmo\API\Preise") */
-    protected ?Preise $preise = null;
+    public ?Preise $preise = null;
 
     /** @Type("Ujamii\OpenImmo\API\Bieterverfahren") */
-    protected ?Bieterverfahren $bieterverfahren = null;
+    public ?Bieterverfahren $bieterverfahren = null;
 
     /** @Type("Ujamii\OpenImmo\API\Versteigerung") */
-    protected ?Versteigerung $versteigerung = null;
+    public ?Versteigerung $versteigerung = null;
 
     /** @Type("Ujamii\OpenImmo\API\Flaechen") */
-    protected ?Flaechen $flaechen = null;
+    public ?Flaechen $flaechen = null;
 
     /** @Type("Ujamii\OpenImmo\API\Ausstattung") */
-    protected ?Ausstattung $ausstattung = null;
+    public ?Ausstattung $ausstattung = null;
 
     /** @Type("Ujamii\OpenImmo\API\ZustandAngaben") */
-    protected ?ZustandAngaben $zustandAngaben = null;
+    public ?ZustandAngaben $zustandAngaben = null;
 
     /** @Type("Ujamii\OpenImmo\API\Bewertung") */
-    protected ?Bewertung $bewertung = null;
+    public ?Bewertung $bewertung = null;
 
     /** @Type("Ujamii\OpenImmo\API\Infrastruktur") */
-    protected ?Infrastruktur $infrastruktur = null;
+    public ?Infrastruktur $infrastruktur = null;
 
     /** @Type("Ujamii\OpenImmo\API\Freitexte") */
-    protected ?Freitexte $freitexte = null;
+    public ?Freitexte $freitexte = null;
 
     /** @Type("Ujamii\OpenImmo\API\Anhaenge") */
-    protected ?Anhaenge $anhaenge = null;
+    public ?Anhaenge $anhaenge = null;
 
     /** @Type("Ujamii\OpenImmo\API\VerwaltungObjekt") */
-    protected ?VerwaltungObjekt $verwaltungObjekt = null;
+    public ?VerwaltungObjekt $verwaltungObjekt = null;
 
     /** @Type("Ujamii\OpenImmo\API\VerwaltungTechn") */
-    protected ?VerwaltungTechn $verwaltungTechn = null;
+    public ?VerwaltungTechn $verwaltungTechn = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getObjektkategorie(): ?Objektkategorie
     {

--- a/src/API/ImpressumStrukt.php
+++ b/src/API/ImpressumStrukt.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class ImpressumStrukt
- * Ergänzung ($V120)
+ * ErgÃ¤nzung ($V120)
  * @XmlRoot("impressum_strukt")
  */
 class ImpressumStrukt
@@ -17,61 +17,61 @@ class ImpressumStrukt
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $firmenname = '';
+    public string $firmenname = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $firmenanschrift = '';
+    public string $firmenanschrift = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $telefon = '';
+    public string $telefon = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $vertretungsberechtigter = '';
+    public string $vertretungsberechtigter = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $berufsaufsichtsbehoerde = '';
+    public string $berufsaufsichtsbehoerde = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $handelsregister = '';
+    public string $handelsregister = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $handelsregisterNr = '';
+    public string $handelsregisterNr = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $umsstId = '';
+    public string $umsstId = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $steuernummer = '';
+    public string $steuernummer = '';
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $weiteres = '';
+    public string $weiteres = '';
 
     public function getFirmenname(): string
     {

--- a/src/API/Infrastruktur.php
+++ b/src/API/Infrastruktur.php
@@ -15,45 +15,45 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Infrastruktur
 {
     /** @Type("bool") */
-    protected ?bool $zulieferung = null;
+    public ?bool $zulieferung = null;
 
     /** @Type("Ujamii\OpenImmo\API\Ausblick") */
-    protected ?Ausblick $ausblick = null;
+    public ?Ausblick $ausblick = null;
 
     /**
      * @XmlList(inline = true, entry = "distanzen")
      * @Type("array<Ujamii\OpenImmo\API\Distanzen>")
      * @SkipWhenEmpty
      */
-    protected array $distanzen = [];
+    public array $distanzen = [];
 
     /**
      * @XmlList(inline = true, entry = "distanzen_sport")
      * @Type("array<Ujamii\OpenImmo\API\DistanzenSport>")
      * @SkipWhenEmpty
      */
-    protected array $distanzenSport = [];
+    public array $distanzenSport = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getZulieferung(): ?bool
     {

--- a/src/API/InnenCourtage.php
+++ b/src/API/InnenCourtage.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class InnenCourtage
- * Maklercourtage, bei Vermittlungs- bzw. Nachweisgeschäften als Betrag in ? / % / MM, daher Textfeld
+ * Maklercourtage, bei Vermittlungs- bzw. NachweisgeschÃ¤ften als Betrag in ? / % / MM, daher Textfeld
  * @XmlRoot("innen_courtage")
  */
 class InnenCourtage
@@ -19,13 +19,13 @@ class InnenCourtage
      * @XmlAttribute
      * optional
      */
-    protected ?bool $mitMwst = null;
+    public ?bool $mitMwst = null;
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getMitMwst(): ?bool
     {

--- a/src/API/Kaufpreis.php
+++ b/src/API/Kaufpreis.php
@@ -19,13 +19,13 @@ class Kaufpreis
      * @XmlAttribute
      * optional
      */
-    protected ?bool $aufAnfrage = null;
+    public ?bool $aufAnfrage = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getAufAnfrage(): ?bool
     {

--- a/src/API/Kaufpreisnetto.php
+++ b/src/API/Kaufpreisnetto.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Kaufpreisnetto
- * Ausgewiesene Kaufpreis Netto, Optional mit Umst im Attribut. Speziell für Gewerbe
+ * Ausgewiesene Kaufpreis Netto, Optional mit Umst im Attribut. Speziell fÃ¼r Gewerbe
  * @XmlRoot("kaufpreisnetto")
  */
 class Kaufpreisnetto
@@ -19,13 +19,13 @@ class Kaufpreisnetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $kaufpreisust = null;
+    public ?float $kaufpreisust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getKaufpreisust(): ?float
     {

--- a/src/API/Kontaktperson.php
+++ b/src/API/Kontaktperson.php
@@ -18,162 +18,162 @@ class Kontaktperson
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $emailZentrale = null;
+    public ?string $emailZentrale = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $emailDirekt = null;
+    public ?string $emailDirekt = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telZentrale = null;
+    public ?string $telZentrale = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telDurchw = null;
+    public ?string $telDurchw = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telFax = null;
+    public ?string $telFax = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telHandy = null;
+    public ?string $telHandy = null;
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $name = '';
+    public string $name = '';
 
     /** @Type("string") */
-    protected ?string $vorname = null;
+    public ?string $vorname = null;
 
     /** @Type("string") */
-    protected ?string $titel = null;
+    public ?string $titel = null;
 
     /** @Type("string") */
-    protected ?string $anrede = null;
+    public ?string $anrede = null;
 
     /** @Type("string") */
-    protected ?string $position = null;
+    public ?string $position = null;
 
     /** @Type("string") */
-    protected ?string $anredeBrief = null;
+    public ?string $anredeBrief = null;
 
     /** @Type("string") */
-    protected ?string $firma = null;
+    public ?string $firma = null;
 
     /** @Type("string") */
-    protected ?string $zusatzfeld = null;
+    public ?string $zusatzfeld = null;
 
     /** @Type("string") */
-    protected ?string $strasse = null;
+    public ?string $strasse = null;
 
     /** @Type("string") */
-    protected ?string $hausnummer = null;
+    public ?string $hausnummer = null;
 
     /** @Type("string") */
-    protected ?string $plz = null;
+    public ?string $plz = null;
 
     /** @Type("string") */
-    protected ?string $ort = null;
+    public ?string $ort = null;
 
     /** @Type("string") */
-    protected ?string $postfach = null;
+    public ?string $postfach = null;
 
     /** @Type("string") */
-    protected ?string $postfPlz = null;
+    public ?string $postfPlz = null;
 
     /** @Type("string") */
-    protected ?string $postfOrt = null;
+    public ?string $postfOrt = null;
 
     /** @Type("Ujamii\OpenImmo\API\Land") */
-    protected ?Land $land = null;
+    public ?Land $land = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $emailPrivat = null;
+    public ?string $emailPrivat = null;
 
     /**
      * @XmlList(inline = true, entry = "email_sonstige")
      * @Type("array<Ujamii\OpenImmo\API\EmailSonstige>")
      * @SkipWhenEmpty
      */
-    protected array $emailSonstige = [];
+    public array $emailSonstige = [];
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $emailFeedback = null;
+    public ?string $emailFeedback = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telPrivat = null;
+    public ?string $telPrivat = null;
 
     /**
      * @XmlList(inline = true, entry = "tel_sonstige")
      * @Type("array<Ujamii\OpenImmo\API\TelSonstige>")
      * @SkipWhenEmpty
      */
-    protected array $telSonstige = [];
+    public array $telSonstige = [];
 
     /** @Type("string") */
-    protected ?string $url = null;
+    public ?string $url = null;
 
     /** @Type("bool") */
-    protected ?bool $adressfreigabe = null;
+    public ?bool $adressfreigabe = null;
 
     /** @Type("string") */
-    protected ?string $personennummer = null;
+    public ?string $personennummer = null;
 
     /** @Type("string") */
-    protected ?string $immobilientreuhaenderid = null;
+    public ?string $immobilientreuhaenderid = null;
 
     /** @Type("Ujamii\OpenImmo\API\Foto") */
-    protected ?Foto $foto = null;
+    public ?Foto $foto = null;
 
     /** @Type("string") */
-    protected ?string $referenzId = null;
+    public ?string $referenzId = null;
 
     /** @Type("string") */
-    protected ?string $freitextfeld = null;
+    public ?string $freitextfeld = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getEmailZentrale(): ?string
     {

--- a/src/API/Kueche.php
+++ b/src/API/Kueche.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Kueche
- * Welche Eigenschaften besitzt die Küche, Optionen kombinierbar
+ * Welche Eigenschaften besitzt die KÃ¼che, Optionen kombinierbar
  * @XmlRoot("kueche")
  */
 class Kueche
@@ -20,7 +20,7 @@ class Kueche
      * @SerializedName("EBK")
      * optional
      */
-    protected ?bool $ebk = null;
+    public ?bool $ebk = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Kueche
      * @SerializedName("OFFEN")
      * optional
      */
-    protected ?bool $offen = null;
+    public ?bool $offen = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Kueche
      * @SerializedName("PANTRY")
      * optional
      */
-    protected ?bool $pantry = null;
+    public ?bool $pantry = null;
 
     public function getEbk(): ?bool
     {

--- a/src/API/LageGebiet.php
+++ b/src/API/LageGebiet.php
@@ -33,7 +33,7 @@ class LageGebiet
      * optional
      * @see GEBIETE_* constants
      */
-    protected string $gebiete = '';
+    public string $gebiete = '';
 
     public function getGebiete(): ?string
     {

--- a/src/API/LageImBau.php
+++ b/src/API/LageImBau.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class LageImBau
- * Angabe über die Lage der Immobilie im Gesamtgebäude, Optionen kombinierbar
+ * Angabe Ã¼ber die Lage der Immobilie im GesamtgebÃ¤ude, Optionen kombinierbar
  * @XmlRoot("lage_im_bau")
  */
 class LageImBau
@@ -20,7 +20,7 @@ class LageImBau
      * @SerializedName("LINKS")
      * optional
      */
-    protected ?bool $links = null;
+    public ?bool $links = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class LageImBau
      * @SerializedName("RECHTS")
      * optional
      */
-    protected ?bool $rechts = null;
+    public ?bool $rechts = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class LageImBau
      * @SerializedName("VORNE")
      * optional
      */
-    protected ?bool $vorne = null;
+    public ?bool $vorne = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class LageImBau
      * @SerializedName("HINTEN")
      * optional
      */
-    protected ?bool $hinten = null;
+    public ?bool $hinten = null;
 
     public function getLinks(): ?bool
     {

--- a/src/API/Land.php
+++ b/src/API/Land.php
@@ -252,7 +252,7 @@ class Land
      * optional
      * @see ISO_LAND_* constants
      */
-    protected string $isoLand = '';
+    public string $isoLand = '';
 
     public function getIsoLand(): ?string
     {

--- a/src/API/LandUndForstwirtschaft.php
+++ b/src/API/LandUndForstwirtschaft.php
@@ -34,7 +34,7 @@ class LandUndForstwirtschaft
      * optional
      * @see LAND_TYP_* constants
      */
-    protected string $landTyp = '';
+    public string $landTyp = '';
 
     public function getLandTyp(): ?string
     {

--- a/src/API/Master.php
+++ b/src/API/Master.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Master
- * Frei wählbare alphanumerische Kennung um Objekte einem Übergeordneten Objekt zuzuordnen.
+ * Frei wÃ¤hlbare alphanumerische Kennung um Objekte einem Ãbergeordneten Objekt zuzuordnen.
  * Das Eltern Objekte hat in "gruppen_kennung" die gleiche ID wie "master". Anwendung z.b. in Neubau Projekten.
  * Damit die Anzeige des Master Objektes gesteuert werden kann, wird im Master ein Flag
  *  visible eingesetzt. Das Attribut ist dann zwingend anzugeben
@@ -22,13 +22,13 @@ class Master
      * @XmlAttribute
      * required
      */
-    protected bool $visible = false;
+    public bool $visible = false;
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getVisible(): bool
     {

--- a/src/API/MaxMietdauer.php
+++ b/src/API/MaxMietdauer.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class MaxMietdauer
- * Maximalzeitraum für den die Immobilie gemietet werdenkann, Optionen nicht kombinierbar, vorrangig bei WaZ
+ * Maximalzeitraum fÃ¼r den die Immobilie gemietet werdenkann, Optionen nicht kombinierbar, vorrangig bei WaZ
  * @XmlRoot("max_mietdauer")
  */
 class MaxMietdauer
@@ -25,13 +25,13 @@ class MaxMietdauer
      * optional
      * @see MAX_DAUER_* constants
      */
-    protected string $maxDauer = '';
+    public string $maxDauer = '';
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getMaxDauer(): ?string
     {

--- a/src/API/MieteinnahmenIst.php
+++ b/src/API/MieteinnahmenIst.php
@@ -25,13 +25,13 @@ class MieteinnahmenIst
      * optional
      * @see PERIODE_* constants
      */
-    protected string $periode = '';
+    public string $periode = '';
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getPeriode(): ?string
     {

--- a/src/API/MieteinnahmenSoll.php
+++ b/src/API/MieteinnahmenSoll.php
@@ -25,13 +25,13 @@ class MieteinnahmenSoll
      * optional
      * @see PERIODE_* constants
      */
-    protected string $periode = '';
+    public string $periode = '';
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getPeriode(): ?string
     {

--- a/src/API/MinMietdauer.php
+++ b/src/API/MinMietdauer.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class MinMietdauer
- * Mindestzeitraum für den die Immobilie gemietet werden muss, Optionen nicht kombinierbar, vorrangig bei WaZ
+ * Mindestzeitraum fÃ¼r den die Immobilie gemietet werden muss, Optionen nicht kombinierbar, vorrangig bei WaZ
  * @XmlRoot("min_mietdauer")
  */
 class MinMietdauer
@@ -25,13 +25,13 @@ class MinMietdauer
      * optional
      * @see MIN_DAUER_* constants
      */
-    protected string $minDauer = '';
+    public string $minDauer = '';
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getMinDauer(): ?string
     {

--- a/src/API/Moebliert.php
+++ b/src/API/Moebliert.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Moebliert
- * Wie ist die Möblierung: Voll, Teil oder keine Aussage
+ * Wie ist die MÃ¶blierung: Voll, Teil oder keine Aussage
  * @XmlRoot("moebliert")
  */
 class Moebliert
@@ -22,7 +22,7 @@ class Moebliert
      * optional
      * @see MOEB_* constants
      */
-    protected string $moeb = '';
+    public string $moeb = '';
 
     public function getMoeb(): ?string
     {

--- a/src/API/Monatlichekostennetto.php
+++ b/src/API/Monatlichekostennetto.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Monatlichekostennetto
- * Summe der Monatlichen Kosten einer Wohnung als Information für einen Käufer (Netto), Umst im Attribut.
+ * Summe der Monatlichen Kosten einer Wohnung als Information fÃ¼r einen KÃ¤ufer (Netto), Umst im Attribut.
  * @XmlRoot("monatlichekostennetto")
  */
 class Monatlichekostennetto
@@ -19,13 +19,13 @@ class Monatlichekostennetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $monatlichekostenust = null;
+    public ?float $monatlichekostenust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getMonatlichekostenust(): ?float
     {

--- a/src/API/Nebenkostenprom2von.php
+++ b/src/API/Nebenkostenprom2von.php
@@ -19,13 +19,13 @@ class Nebenkostenprom2von
      * @XmlAttribute
      * optional
      */
-    protected ?float $nebenkostenprom2bis = null;
+    public ?float $nebenkostenprom2bis = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getNebenkostenprom2bis(): ?float
     {

--- a/src/API/Nettomieteprom2von.php
+++ b/src/API/Nettomieteprom2von.php
@@ -19,13 +19,13 @@ class Nettomieteprom2von
      * @XmlAttribute
      * optional
      */
-    protected ?float $nettomieteprom2bis = null;
+    public ?float $nettomieteprom2bis = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getNettomieteprom2bis(): ?float
     {

--- a/src/API/Nutzungsart.php
+++ b/src/API/Nutzungsart.php
@@ -20,7 +20,7 @@ class Nutzungsart
      * @SerializedName("WOHNEN")
      * required
      */
-    protected bool $wohnen = false;
+    public bool $wohnen = false;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Nutzungsart
      * @SerializedName("GEWERBE")
      * required
      */
-    protected bool $gewerbe = false;
+    public bool $gewerbe = false;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Nutzungsart
      * @SerializedName("ANLAGE")
      * optional
      */
-    protected ?bool $anlage = null;
+    public ?bool $anlage = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Nutzungsart
      * @SerializedName("WAZ")
      * optional
      */
-    protected ?bool $waz = null;
+    public ?bool $waz = null;
 
     public function getWohnen(): bool
     {

--- a/src/API/ObjektText.php
+++ b/src/API/ObjektText.php
@@ -20,13 +20,13 @@ class ObjektText
      * @XmlAttribute
      * required
      */
-    protected string $lang = '';
+    public string $lang = '';
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getLang(): string
     {

--- a/src/API/Objektart.php
+++ b/src/API/Objektart.php
@@ -19,98 +19,98 @@ class Objektart
      * @Type("array<Ujamii\OpenImmo\API\Zimmer>")
      * @SkipWhenEmpty
      */
-    protected array $zimmer = [];
+    public array $zimmer = [];
 
     /**
      * @XmlList(inline = true, entry = "wohnung")
      * @Type("array<Ujamii\OpenImmo\API\Wohnung>")
      * @SkipWhenEmpty
      */
-    protected array $wohnung = [];
+    public array $wohnung = [];
 
     /**
      * @XmlList(inline = true, entry = "haus")
      * @Type("array<Ujamii\OpenImmo\API\Haus>")
      * @SkipWhenEmpty
      */
-    protected array $haus = [];
+    public array $haus = [];
 
     /**
      * @XmlList(inline = true, entry = "grundstueck")
      * @Type("array<Ujamii\OpenImmo\API\Grundstueck>")
      * @SkipWhenEmpty
      */
-    protected array $grundstueck = [];
+    public array $grundstueck = [];
 
     /**
      * @XmlList(inline = true, entry = "buero_praxen")
      * @Type("array<Ujamii\OpenImmo\API\BueroPraxen>")
      * @SkipWhenEmpty
      */
-    protected array $bueroPraxen = [];
+    public array $bueroPraxen = [];
 
     /**
      * @XmlList(inline = true, entry = "einzelhandel")
      * @Type("array<Ujamii\OpenImmo\API\Einzelhandel>")
      * @SkipWhenEmpty
      */
-    protected array $einzelhandel = [];
+    public array $einzelhandel = [];
 
     /**
      * @XmlList(inline = true, entry = "gastgewerbe")
      * @Type("array<Ujamii\OpenImmo\API\Gastgewerbe>")
      * @SkipWhenEmpty
      */
-    protected array $gastgewerbe = [];
+    public array $gastgewerbe = [];
 
     /**
      * @XmlList(inline = true, entry = "hallen_lager_prod")
      * @Type("array<Ujamii\OpenImmo\API\HallenLagerProd>")
      * @SkipWhenEmpty
      */
-    protected array $hallenLagerProd = [];
+    public array $hallenLagerProd = [];
 
     /**
      * @XmlList(inline = true, entry = "land_und_forstwirtschaft")
      * @Type("array<Ujamii\OpenImmo\API\LandUndForstwirtschaft>")
      * @SkipWhenEmpty
      */
-    protected array $landUndForstwirtschaft = [];
+    public array $landUndForstwirtschaft = [];
 
     /**
      * @XmlList(inline = true, entry = "parken")
      * @Type("array<Ujamii\OpenImmo\API\Parken>")
      * @SkipWhenEmpty
      */
-    protected array $parken = [];
+    public array $parken = [];
 
     /**
      * @XmlList(inline = true, entry = "sonstige")
      * @Type("array<Ujamii\OpenImmo\API\Sonstige>")
      * @SkipWhenEmpty
      */
-    protected array $sonstige = [];
+    public array $sonstige = [];
 
     /**
      * @XmlList(inline = true, entry = "freizeitimmobilie_gewerblich")
      * @Type("array<Ujamii\OpenImmo\API\FreizeitimmobilieGewerblich>")
      * @SkipWhenEmpty
      */
-    protected array $freizeitimmobilieGewerblich = [];
+    public array $freizeitimmobilieGewerblich = [];
 
     /**
      * @XmlList(inline = true, entry = "zinshaus_renditeobjekt")
      * @Type("array<Ujamii\OpenImmo\API\ZinshausRenditeobjekt>")
      * @SkipWhenEmpty
      */
-    protected array $zinshausRenditeobjekt = [];
+    public array $zinshausRenditeobjekt = [];
 
     /**
      * @XmlList(inline = true, entry = "objektart_zusatz")
      * @Type("array<string>")
      * @SkipWhenEmpty
      */
-    protected array $objektartZusatz = [];
+    public array $objektartZusatz = [];
 
     /**
      * Returns array of array

--- a/src/API/Objektkategorie.php
+++ b/src/API/Objektkategorie.php
@@ -15,34 +15,34 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Objektkategorie
 {
     /** @Type("Ujamii\OpenImmo\API\Nutzungsart") */
-    protected ?Nutzungsart $nutzungsart = null;
+    public ?Nutzungsart $nutzungsart = null;
 
     /** @Type("Ujamii\OpenImmo\API\Vermarktungsart") */
-    protected ?Vermarktungsart $vermarktungsart = null;
+    public ?Vermarktungsart $vermarktungsart = null;
 
     /** @Type("Ujamii\OpenImmo\API\Objektart") */
-    protected ?Objektart $objektart = null;
+    public ?Objektart $objektart = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getNutzungsart(): ?Nutzungsart
     {
@@ -125,7 +125,7 @@ class Objektkategorie
         ?Objektart $objektart = null,
         array $userDefinedSimplefield = [],
         array $userDefinedAnyfield = [],
-        array $userDefinedExtend = []
+        array $userDefinedExtend = [],
     ) {
         $this->nutzungsart = $nutzungsart;
         $this->vermarktungsart = $vermarktungsart;

--- a/src/API/Openimmo.php
+++ b/src/API/Openimmo.php
@@ -16,28 +16,28 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Openimmo
 {
     /** @Type("Ujamii\OpenImmo\API\Uebertragung") */
-    protected ?Uebertragung $uebertragung = null;
+    public ?Uebertragung $uebertragung = null;
 
     /**
      * @XmlList(inline = true, entry = "anbieter")
      * @Type("array<Ujamii\OpenImmo\API\Anbieter>")
      * @SkipWhenEmpty
      */
-    protected array $anbieter = [];
+    public array $anbieter = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     public function getUebertragung(): ?Uebertragung
     {
@@ -96,7 +96,7 @@ class Openimmo
         ?Uebertragung $uebertragung = null,
         array $anbieter = [],
         array $userDefinedSimplefield = [],
-        array $userDefinedAnyfield = []
+        array $userDefinedAnyfield = [],
     ) {
         $this->uebertragung = $uebertragung;
         $this->anbieter = $anbieter;

--- a/src/API/Parken.php
+++ b/src/API/Parken.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Parken
- * Objektart für diverse Parkplatz Angaben
+ * Objektart fÃ¼r diverse Parkplatz Angaben
  * @XmlRoot("parken")
  */
 class Parken
@@ -30,7 +30,7 @@ class Parken
      * optional
      * @see PARKEN_TYP_* constants
      */
-    protected string $parkenTyp = '';
+    public string $parkenTyp = '';
 
     public function getParkenTyp(): ?string
     {

--- a/src/API/PreisZeiteinheit.php
+++ b/src/API/PreisZeiteinheit.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class PreisZeiteinheit
- * Zeiteinheit für die der Preis gilt, vorrangig bei Ferienobjekten
+ * Zeiteinheit fÃ¼r die der Preis gilt, vorrangig bei Ferienobjekten
  * @XmlRoot("preis_zeiteinheit")
  */
 class PreisZeiteinheit
@@ -24,7 +24,7 @@ class PreisZeiteinheit
      * optional
      * @see ZEITEINHEIT_* constants
      */
-    protected string $zeiteinheit = '';
+    public string $zeiteinheit = '';
 
     public function getZeiteinheit(): ?string
     {

--- a/src/API/Preise.php
+++ b/src/API/Preise.php
@@ -15,241 +15,241 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Preise
 {
     /** @Type("Ujamii\OpenImmo\API\Kaufpreis") */
-    protected ?Kaufpreis $kaufpreis = null;
+    public ?Kaufpreis $kaufpreis = null;
 
     /** @Type("Ujamii\OpenImmo\API\Kaufpreisnetto") */
-    protected ?Kaufpreisnetto $kaufpreisnetto = null;
+    public ?Kaufpreisnetto $kaufpreisnetto = null;
 
     /** @Type("float") */
-    protected ?float $kaufpreisbrutto = null;
+    public ?float $kaufpreisbrutto = null;
 
     /** @Type("float") */
-    protected ?float $nettokaltmiete = null;
+    public ?float $nettokaltmiete = null;
 
     /** @Type("float") */
-    protected ?float $kaltmiete = null;
+    public ?float $kaltmiete = null;
 
     /** @Type("float") */
-    protected ?float $warmmiete = null;
+    public ?float $warmmiete = null;
 
     /** @Type("float") */
-    protected ?float $nebenkosten = null;
+    public ?float $nebenkosten = null;
 
     /** @Type("bool") */
-    protected ?bool $heizkostenEnthalten = null;
+    public ?bool $heizkostenEnthalten = null;
 
     /** @Type("float") */
-    protected ?float $heizkosten = null;
+    public ?float $heizkosten = null;
 
     /** @Type("bool") */
-    protected ?bool $zzgMehrwertsteuer = null;
+    public ?bool $zzgMehrwertsteuer = null;
 
     /** @Type("float") */
-    protected ?float $mietzuschlaege = null;
+    public ?float $mietzuschlaege = null;
 
     /** @Type("Ujamii\OpenImmo\API\Hauptmietzinsnetto") */
-    protected ?Hauptmietzinsnetto $hauptmietzinsnetto = null;
+    public ?Hauptmietzinsnetto $hauptmietzinsnetto = null;
 
     /** @Type("float") */
-    protected ?float $pauschalmiete = null;
+    public ?float $pauschalmiete = null;
 
     /** @Type("Ujamii\OpenImmo\API\Betriebskostennetto") */
-    protected ?Betriebskostennetto $betriebskostennetto = null;
+    public ?Betriebskostennetto $betriebskostennetto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Evbnetto") */
-    protected ?Evbnetto $evbnetto = null;
+    public ?Evbnetto $evbnetto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Gesamtmietenetto") */
-    protected ?Gesamtmietenetto $gesamtmietenetto = null;
+    public ?Gesamtmietenetto $gesamtmietenetto = null;
 
     /** @Type("float") */
-    protected ?float $gesamtmietebrutto = null;
+    public ?float $gesamtmietebrutto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Gesamtbelastungnetto") */
-    protected ?Gesamtbelastungnetto $gesamtbelastungnetto = null;
+    public ?Gesamtbelastungnetto $gesamtbelastungnetto = null;
 
     /** @Type("float") */
-    protected ?float $gesamtbelastungbrutto = null;
+    public ?float $gesamtbelastungbrutto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Gesamtkostenprom2von") */
-    protected ?Gesamtkostenprom2von $gesamtkostenprom2von = null;
+    public ?Gesamtkostenprom2von $gesamtkostenprom2von = null;
 
     /** @Type("Ujamii\OpenImmo\API\Heizkostennetto") */
-    protected ?Heizkostennetto $heizkostennetto = null;
+    public ?Heizkostennetto $heizkostennetto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Monatlichekostennetto") */
-    protected ?Monatlichekostennetto $monatlichekostennetto = null;
+    public ?Monatlichekostennetto $monatlichekostennetto = null;
 
     /** @Type("float") */
-    protected ?float $monatlichekostenbrutto = null;
+    public ?float $monatlichekostenbrutto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Nebenkostenprom2von") */
-    protected ?Nebenkostenprom2von $nebenkostenprom2von = null;
+    public ?Nebenkostenprom2von $nebenkostenprom2von = null;
 
     /** @Type("Ujamii\OpenImmo\API\Ruecklagenetto") */
-    protected ?Ruecklagenetto $ruecklagenetto = null;
+    public ?Ruecklagenetto $ruecklagenetto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Sonstigekostennetto") */
-    protected ?Sonstigekostennetto $sonstigekostennetto = null;
+    public ?Sonstigekostennetto $sonstigekostennetto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Sonstigemietenetto") */
-    protected ?Sonstigemietenetto $sonstigemietenetto = null;
+    public ?Sonstigemietenetto $sonstigemietenetto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Summemietenetto") */
-    protected ?Summemietenetto $summemietenetto = null;
+    public ?Summemietenetto $summemietenetto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Nettomieteprom2von") */
-    protected ?Nettomieteprom2von $nettomieteprom2von = null;
+    public ?Nettomieteprom2von $nettomieteprom2von = null;
 
     /** @Type("float") */
-    protected ?float $pacht = null;
+    public ?float $pacht = null;
 
     /** @Type("float") */
-    protected ?float $erbpacht = null;
+    public ?float $erbpacht = null;
 
     /** @Type("float") */
-    protected ?float $hausgeld = null;
+    public ?float $hausgeld = null;
 
     /** @Type("float") */
-    protected ?float $abstand = null;
+    public ?float $abstand = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $preisZeitraumVon = null;
+    public ?\DateTime $preisZeitraumVon = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $preisZeitraumBis = null;
+    public ?\DateTime $preisZeitraumBis = null;
 
     /** @Type("Ujamii\OpenImmo\API\PreisZeiteinheit") */
-    protected ?PreisZeiteinheit $preisZeiteinheit = null;
+    public ?PreisZeiteinheit $preisZeiteinheit = null;
 
     /** @Type("float") */
-    protected ?float $mietpreisProQm = null;
+    public ?float $mietpreisProQm = null;
 
     /** @Type("float") */
-    protected ?float $kaufpreisProQm = null;
+    public ?float $kaufpreisProQm = null;
 
     /** @Type("bool") */
-    protected ?bool $provisionspflichtig = null;
+    public ?bool $provisionspflichtig = null;
 
     /** @Type("Ujamii\OpenImmo\API\ProvisionTeilen") */
-    protected ?ProvisionTeilen $provisionTeilen = null;
+    public ?ProvisionTeilen $provisionTeilen = null;
 
     /** @Type("Ujamii\OpenImmo\API\InnenCourtage") */
-    protected ?InnenCourtage $innenCourtage = null;
+    public ?InnenCourtage $innenCourtage = null;
 
     /** @Type("Ujamii\OpenImmo\API\AussenCourtage") */
-    protected ?AussenCourtage $aussenCourtage = null;
+    public ?AussenCourtage $aussenCourtage = null;
 
     /** @Type("string") */
-    protected ?string $courtageHinweis = null;
+    public ?string $courtageHinweis = null;
 
     /** @Type("Ujamii\OpenImmo\API\Provisionnetto") */
-    protected ?Provisionnetto $provisionnetto = null;
+    public ?Provisionnetto $provisionnetto = null;
 
     /** @Type("float") */
-    protected ?float $provisionbrutto = null;
+    public ?float $provisionbrutto = null;
 
     /** @Type("Ujamii\OpenImmo\API\Waehrung") */
-    protected ?Waehrung $waehrung = null;
+    public ?Waehrung $waehrung = null;
 
     /**
      * @Type("float")
      * Maximum precision: 2
      * Minimum value (inclusive): 0
      */
-    protected ?float $mwstSatz = null;
+    public ?float $mwstSatz = null;
 
     /**
      * @Type("float")
      * Maximum precision: 2
      * Minimum value (inclusive): 0
      */
-    protected ?float $mwstGesamt = null;
+    public ?float $mwstGesamt = null;
 
     /** @Type("string") */
-    protected ?string $freitextPreis = null;
+    public ?string $freitextPreis = null;
 
     /** @Type("string") */
-    protected ?string $xFache = null;
+    public ?string $xFache = null;
 
     /** @Type("float") */
-    protected ?float $nettorendite = null;
+    public ?float $nettorendite = null;
 
     /** @Type("float") */
-    protected ?float $nettorenditeSoll = null;
+    public ?float $nettorenditeSoll = null;
 
     /** @Type("float") */
-    protected ?float $nettorenditeIst = null;
+    public ?float $nettorenditeIst = null;
 
     /** @Type("Ujamii\OpenImmo\API\MieteinnahmenIst") */
-    protected ?MieteinnahmenIst $mieteinnahmenIst = null;
+    public ?MieteinnahmenIst $mieteinnahmenIst = null;
 
     /** @Type("Ujamii\OpenImmo\API\MieteinnahmenSoll") */
-    protected ?MieteinnahmenSoll $mieteinnahmenSoll = null;
+    public ?MieteinnahmenSoll $mieteinnahmenSoll = null;
 
     /** @Type("float") */
-    protected ?float $erschliessungskosten = null;
+    public ?float $erschliessungskosten = null;
 
     /** @Type("float") */
-    protected ?float $kaution = null;
+    public ?float $kaution = null;
 
     /** @Type("string") */
-    protected ?string $kautionText = null;
+    public ?string $kautionText = null;
 
     /** @Type("float") */
-    protected ?float $geschaeftsguthaben = null;
+    public ?float $geschaeftsguthaben = null;
 
     /** @Type("Ujamii\OpenImmo\API\StpCarport") */
-    protected ?StpCarport $stpCarport = null;
+    public ?StpCarport $stpCarport = null;
 
     /** @Type("Ujamii\OpenImmo\API\StpDuplex") */
-    protected ?StpDuplex $stpDuplex = null;
+    public ?StpDuplex $stpDuplex = null;
 
     /** @Type("Ujamii\OpenImmo\API\StpFreiplatz") */
-    protected ?StpFreiplatz $stpFreiplatz = null;
+    public ?StpFreiplatz $stpFreiplatz = null;
 
     /** @Type("Ujamii\OpenImmo\API\StpGarage") */
-    protected ?StpGarage $stpGarage = null;
+    public ?StpGarage $stpGarage = null;
 
     /** @Type("Ujamii\OpenImmo\API\StpParkhaus") */
-    protected ?StpParkhaus $stpParkhaus = null;
+    public ?StpParkhaus $stpParkhaus = null;
 
     /** @Type("Ujamii\OpenImmo\API\StpTiefgarage") */
-    protected ?StpTiefgarage $stpTiefgarage = null;
+    public ?StpTiefgarage $stpTiefgarage = null;
 
     /**
      * @XmlList(inline = true, entry = "stp_sonstige")
      * @Type("array<Ujamii\OpenImmo\API\StpSonstige>")
      * @SkipWhenEmpty
      */
-    protected array $stpSonstige = [];
+    public array $stpSonstige = [];
 
     /** @Type("float") */
-    protected ?float $richtpreis = null;
+    public ?float $richtpreis = null;
 
     /** @Type("float") */
-    protected ?float $richtpreisprom2 = null;
+    public ?float $richtpreisprom2 = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getKaufpreis(): ?Kaufpreis
     {

--- a/src/API/ProvisionTeilen.php
+++ b/src/API/ProvisionTeilen.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class ProvisionTeilen
- * Aufteilen der provision bei Partnergeschäften. Auch "A Meta" Geschäft. Attribut zeigt, wie der Wert angegeben wird: fester wert, prozent, oder Text Information
+ * Aufteilen der provision bei PartnergeschÃ¤ften. Auch "A Meta" GeschÃ¤ft. Attribut zeigt, wie der Wert angegeben wird: fester wert, prozent, oder Text Information
  * @XmlRoot("provision_teilen")
  */
 class ProvisionTeilen
@@ -24,13 +24,13 @@ class ProvisionTeilen
      * optional
      * @see WERT_* constants
      */
-    protected string $wert = '';
+    public string $wert = '';
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getWert(): ?string
     {

--- a/src/API/Provisionnetto.php
+++ b/src/API/Provisionnetto.php
@@ -19,13 +19,13 @@ class Provisionnetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $provisionust = null;
+    public ?float $provisionust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getProvisionust(): ?float
     {

--- a/src/API/Ruecklagenetto.php
+++ b/src/API/Ruecklagenetto.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Ruecklagenetto
- * Vorhanden Rücklagen bei einem Kauf Objekt, UmSt. im Attribut.
+ * Vorhanden RÃ¼cklagen bei einem Kauf Objekt, UmSt. im Attribut.
  * @XmlRoot("ruecklagenetto")
  */
 class Ruecklagenetto
@@ -19,13 +19,13 @@ class Ruecklagenetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $ruecklageust = null;
+    public ?float $ruecklageust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getRuecklageust(): ?float
     {

--- a/src/API/Serviceleistungen.php
+++ b/src/API/Serviceleistungen.php
@@ -20,7 +20,7 @@ class Serviceleistungen
      * @SerializedName("BETREUTES_WOHNEN")
      * optional
      */
-    protected ?bool $betreutesWohnen = null;
+    public ?bool $betreutesWohnen = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Serviceleistungen
      * @SerializedName("CATERING")
      * optional
      */
-    protected ?bool $catering = null;
+    public ?bool $catering = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Serviceleistungen
      * @SerializedName("REINIGUNG")
      * optional
      */
-    protected ?bool $reinigung = null;
+    public ?bool $reinigung = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Serviceleistungen
      * @SerializedName("EINKAUF")
      * optional
      */
-    protected ?bool $einkauf = null;
+    public ?bool $einkauf = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Serviceleistungen
      * @SerializedName("WACHDIENST")
      * optional
      */
-    protected ?bool $wachdienst = null;
+    public ?bool $wachdienst = null;
 
     public function getBetreutesWohnen(): ?bool
     {
@@ -114,7 +114,7 @@ class Serviceleistungen
         ?bool $catering = null,
         ?bool $reinigung = null,
         ?bool $einkauf = null,
-        ?bool $wachdienst = null
+        ?bool $wachdienst = null,
     ) {
         $this->betreutesWohnen = $betreutesWohnen;
         $this->catering = $catering;

--- a/src/API/Sicherheitstechnik.php
+++ b/src/API/Sicherheitstechnik.php
@@ -20,7 +20,7 @@ class Sicherheitstechnik
      * @SerializedName("ALARMANLAGE")
      * optional
      */
-    protected ?bool $alarmanlage = null;
+    public ?bool $alarmanlage = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Sicherheitstechnik
      * @SerializedName("KAMERA")
      * optional
      */
-    protected ?bool $kamera = null;
+    public ?bool $kamera = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Sicherheitstechnik
      * @SerializedName("POLIZEIRUF")
      * optional
      */
-    protected ?bool $polizeiruf = null;
+    public ?bool $polizeiruf = null;
 
     public function getAlarmanlage(): ?bool
     {

--- a/src/API/Sonstige.php
+++ b/src/API/Sonstige.php
@@ -11,8 +11,8 @@ use JMS\Serializer\Annotation\XmlRoot;
  * Objektart / Typ f. Sonstiges
  * Bitte ab Version 1.2.3 die Attribute GARAGEN, PARKFLACHE nicht mehr verwenden.
  * Objekte befinden sich jetzt unter Element parken.
- * Aus kompatibilitätegründen bleiben die Attribute NOCH! erhalten.
- * In nachfolgenden Versionen wird die Unterstützung an dieser Stelle eingestellt.
+ * Aus kompatibilitÃ¤tegrÃ¼nden bleiben die Attribute NOCH! erhalten.
+ * In nachfolgenden Versionen wird die UnterstÃ¼tzung an dieser Stelle eingestellt.
  * @XmlRoot("sonstige")
  */
 class Sonstige
@@ -28,7 +28,7 @@ class Sonstige
      * optional
      * @see SONSTIGE_TYP_* constants
      */
-    protected string $sonstigeTyp = '';
+    public string $sonstigeTyp = '';
 
     public function getSonstigeTyp(): ?string
     {

--- a/src/API/Sonstigekostennetto.php
+++ b/src/API/Sonstigekostennetto.php
@@ -19,13 +19,13 @@ class Sonstigekostennetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $sonstigekostenust = null;
+    public ?float $sonstigekostenust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getSonstigekostenust(): ?float
     {

--- a/src/API/Sonstigemietenetto.php
+++ b/src/API/Sonstigemietenetto.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Sonstigemietenetto
- * Ergänzenden Mietkosten, UmSt. im Attribut.
+ * ErgÃ¤nzenden Mietkosten, UmSt. im Attribut.
  * @XmlRoot("sonstigemietenetto")
  */
 class Sonstigemietenetto
@@ -19,13 +19,13 @@ class Sonstigemietenetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $sonstigemieteust = null;
+    public ?float $sonstigemieteust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getSonstigemieteust(): ?float
     {

--- a/src/API/Stellplatzart.php
+++ b/src/API/Stellplatzart.php
@@ -20,7 +20,7 @@ class Stellplatzart
      * @SerializedName("GARAGE")
      * optional
      */
-    protected ?bool $garage = null;
+    public ?bool $garage = null;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Stellplatzart
      * @SerializedName("TIEFGARAGE")
      * optional
      */
-    protected ?bool $tiefgarage = null;
+    public ?bool $tiefgarage = null;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Stellplatzart
      * @SerializedName("CARPORT")
      * optional
      */
-    protected ?bool $carport = null;
+    public ?bool $carport = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Stellplatzart
      * @SerializedName("FREIPLATZ")
      * optional
      */
-    protected ?bool $freiplatz = null;
+    public ?bool $freiplatz = null;
 
     /**
      * @Type("bool")
@@ -52,7 +52,7 @@ class Stellplatzart
      * @SerializedName("PARKHAUS")
      * optional
      */
-    protected ?bool $parkhaus = null;
+    public ?bool $parkhaus = null;
 
     /**
      * @Type("bool")
@@ -60,7 +60,7 @@ class Stellplatzart
      * @SerializedName("DUPLEX")
      * optional
      */
-    protected ?bool $duplex = null;
+    public ?bool $duplex = null;
 
     public function getGarage(): ?bool
     {
@@ -134,7 +134,7 @@ class Stellplatzart
         ?bool $carport = null,
         ?bool $freiplatz = null,
         ?bool $parkhaus = null,
-        ?bool $duplex = null
+        ?bool $duplex = null,
     ) {
         $this->garage = $garage;
         $this->tiefgarage = $tiefgarage;

--- a/src/API/StpCarport.php
+++ b/src/API/StpCarport.php
@@ -18,14 +18,14 @@ class StpCarport
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzmiete = null;
+    public ?float $stellplatzmiete = null;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzkaufpreis = null;
+    public ?float $stellplatzkaufpreis = null;
 
     /**
      * @Type("int")
@@ -34,7 +34,7 @@ class StpCarport
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $anzahl = null;
+    public ?int $anzahl = null;
 
     public function getStellplatzmiete(): ?float
     {

--- a/src/API/StpDuplex.php
+++ b/src/API/StpDuplex.php
@@ -18,14 +18,14 @@ class StpDuplex
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzmiete = null;
+    public ?float $stellplatzmiete = null;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzkaufpreis = null;
+    public ?float $stellplatzkaufpreis = null;
 
     /**
      * @Type("int")
@@ -34,7 +34,7 @@ class StpDuplex
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $anzahl = null;
+    public ?int $anzahl = null;
 
     public function getStellplatzmiete(): ?float
     {

--- a/src/API/StpFreiplatz.php
+++ b/src/API/StpFreiplatz.php
@@ -18,14 +18,14 @@ class StpFreiplatz
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzmiete = null;
+    public ?float $stellplatzmiete = null;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzkaufpreis = null;
+    public ?float $stellplatzkaufpreis = null;
 
     /**
      * @Type("int")
@@ -34,7 +34,7 @@ class StpFreiplatz
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $anzahl = null;
+    public ?int $anzahl = null;
 
     public function getStellplatzmiete(): ?float
     {

--- a/src/API/StpGarage.php
+++ b/src/API/StpGarage.php
@@ -18,14 +18,14 @@ class StpGarage
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzmiete = null;
+    public ?float $stellplatzmiete = null;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzkaufpreis = null;
+    public ?float $stellplatzkaufpreis = null;
 
     /**
      * @Type("int")
@@ -34,7 +34,7 @@ class StpGarage
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $anzahl = null;
+    public ?int $anzahl = null;
 
     public function getStellplatzmiete(): ?float
     {

--- a/src/API/StpParkhaus.php
+++ b/src/API/StpParkhaus.php
@@ -18,14 +18,14 @@ class StpParkhaus
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzmiete = null;
+    public ?float $stellplatzmiete = null;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzkaufpreis = null;
+    public ?float $stellplatzkaufpreis = null;
 
     /**
      * @Type("int")
@@ -34,7 +34,7 @@ class StpParkhaus
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $anzahl = null;
+    public ?int $anzahl = null;
 
     public function getStellplatzmiete(): ?float
     {

--- a/src/API/StpSonstige.php
+++ b/src/API/StpSonstige.php
@@ -27,14 +27,14 @@ class StpSonstige
      * optional
      * @see PLATZART_* constants
      */
-    protected string $platzart = '';
+    public string $platzart = '';
 
     /**
      * @Type("string")
      * @XmlAttribute
      * optional
      */
-    protected ?string $bemerkung = null;
+    public ?string $bemerkung = null;
 
     public function getPlatzart(): ?string
     {

--- a/src/API/StpTiefgarage.php
+++ b/src/API/StpTiefgarage.php
@@ -18,14 +18,14 @@ class StpTiefgarage
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzmiete = null;
+    public ?float $stellplatzmiete = null;
 
     /**
      * @Type("float")
      * @XmlAttribute
      * optional
      */
-    protected ?float $stellplatzkaufpreis = null;
+    public ?float $stellplatzkaufpreis = null;
 
     /**
      * @Type("int")
@@ -34,7 +34,7 @@ class StpTiefgarage
      * Minimum value (inclusive): -2147483648
      * Maximum value (inclusive): 2147483647
      */
-    protected ?int $anzahl = null;
+    public ?int $anzahl = null;
 
     public function getStellplatzmiete(): ?float
     {

--- a/src/API/Summemietenetto.php
+++ b/src/API/Summemietenetto.php
@@ -19,13 +19,13 @@ class Summemietenetto
      * @XmlAttribute
      * optional
      */
-    protected ?float $summemieteust = null;
+    public ?float $summemieteust = null;
 
     /**
      * @Inline
      * @Type("float")
      */
-    protected ?float $value = null;
+    public ?float $value = null;
 
     public function getSummemieteust(): ?float
     {

--- a/src/API/TelSonstige.php
+++ b/src/API/TelSonstige.php
@@ -27,20 +27,20 @@ class TelSonstige
      * optional
      * @see TELEFONART_* constants
      */
-    protected string $telefonart = '';
+    public string $telefonart = '';
 
     /**
      * @Type("string")
      * @XmlAttribute
      * optional
      */
-    protected ?string $bemerkung = null;
+    public ?string $bemerkung = null;
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getTelefonart(): ?string
     {

--- a/src/API/Uebertragung.php
+++ b/src/API/Uebertragung.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Uebertragung
- * Übertragungsangaben
+ * Ãbertragungsangaben
  * @XmlRoot("uebertragung")
  */
 class Uebertragung
@@ -27,7 +27,7 @@ class Uebertragung
      * required
      * @see ART_* constants
      */
-    protected string $art = '';
+    public string $art = '';
 
     /**
      * @Type("string")
@@ -35,7 +35,7 @@ class Uebertragung
      * required
      * @see UMFANG_* constants
      */
-    protected string $umfang = '';
+    public string $umfang = '';
 
     /**
      * @Type("string")
@@ -43,49 +43,49 @@ class Uebertragung
      * optional
      * @see MODUS_* constants
      */
-    protected string $modus = '';
+    public string $modus = '';
 
     /**
      * @Type("string")
      * @XmlAttribute
      * required
      */
-    protected string $version = '';
+    public string $version = '';
 
     /**
      * @Type("string")
      * @XmlAttribute
      * required
      */
-    protected string $sendersoftware = '';
+    public string $sendersoftware = '';
 
     /**
      * @Type("string")
      * @XmlAttribute
      * required
      */
-    protected string $senderversion = '';
+    public string $senderversion = '';
 
     /**
      * @Type("string")
      * @XmlAttribute
      * optional
      */
-    protected ?string $technEmail = null;
+    public ?string $technEmail = null;
 
     /**
      * @Type("string")
      * @XmlAttribute
      * optional
      */
-    protected ?string $regiId = null;
+    public ?string $regiId = null;
 
     /**
      * @Type("DateTime<'Y-m-d\TH:i:s', null, ['Y-m-d\TH:i:sP', 'Y-m-d\TH:i:s']>")
      * @XmlAttribute
      * optional
      */
-    protected ?\DateTime $timestamp = null;
+    public ?\DateTime $timestamp = null;
 
     public function getArt(): string
     {

--- a/src/API/Unterkellert.php
+++ b/src/API/Unterkellert.php
@@ -23,7 +23,7 @@ class Unterkellert
      * optional
      * @see KELLER_* constants
      */
-    protected string $keller = '';
+    public string $keller = '';
 
     public function getKeller(): ?string
     {

--- a/src/API/UserDefinedAnyfield.php
+++ b/src/API/UserDefinedAnyfield.php
@@ -17,7 +17,7 @@ class UserDefinedAnyfield
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getValue(): ?string
     {

--- a/src/API/UserDefinedExtend.php
+++ b/src/API/UserDefinedExtend.php
@@ -19,7 +19,7 @@ class UserDefinedExtend
      * @Type("array<Ujamii\OpenImmo\API\Feld>")
      * @SkipWhenEmpty
      */
-    protected array $feld = [];
+    public array $feld = [];
 
     /**
      * Returns array of array

--- a/src/API/UserDefinedSimplefield.php
+++ b/src/API/UserDefinedSimplefield.php
@@ -19,13 +19,13 @@ class UserDefinedSimplefield
      * @XmlAttribute
      * required
      */
-    protected string $feldname = '';
+    public string $feldname = '';
 
     /**
      * @Inline
      * @Type("string")
      */
-    protected ?string $value = null;
+    public ?string $value = null;
 
     public function getFeldname(): string
     {

--- a/src/API/Verkaufstatus.php
+++ b/src/API/Verkaufstatus.php
@@ -23,7 +23,7 @@ class Verkaufstatus
      * optional
      * @see STAND_* constants
      */
-    protected string $stand = '';
+    public string $stand = '';
 
     public function getStand(): ?string
     {

--- a/src/API/Vermarktungsart.php
+++ b/src/API/Vermarktungsart.php
@@ -20,7 +20,7 @@ class Vermarktungsart
      * @SerializedName("KAUF")
      * required
      */
-    protected bool $kauf = false;
+    public bool $kauf = false;
 
     /**
      * @Type("bool")
@@ -28,7 +28,7 @@ class Vermarktungsart
      * @SerializedName("MIETE_PACHT")
      * required
      */
-    protected bool $mietePacht = false;
+    public bool $mietePacht = false;
 
     /**
      * @Type("bool")
@@ -36,7 +36,7 @@ class Vermarktungsart
      * @SerializedName("ERBPACHT")
      * optional
      */
-    protected ?bool $erbpacht = null;
+    public ?bool $erbpacht = null;
 
     /**
      * @Type("bool")
@@ -44,7 +44,7 @@ class Vermarktungsart
      * @SerializedName("LEASING")
      * optional
      */
-    protected ?bool $leasing = null;
+    public ?bool $leasing = null;
 
     public function getKauf(): bool
     {
@@ -94,7 +94,7 @@ class Vermarktungsart
         bool $kauf = false,
         bool $mietePacht = false,
         ?bool $erbpacht = null,
-        ?bool $leasing = null
+        ?bool $leasing = null,
     ) {
         $this->kauf = $kauf;
         $this->mietePacht = $mietePacht;

--- a/src/API/Versteigerung.php
+++ b/src/API/Versteigerung.php
@@ -13,22 +13,22 @@ use JMS\Serializer\Annotation\XmlRoot;
 class Versteigerung
 {
     /** @Type("bool") */
-    protected ?bool $zwangsversteigerung = null;
+    public ?bool $zwangsversteigerung = null;
 
     /** @Type("string") */
-    protected ?string $aktenzeichen = null;
+    public ?string $aktenzeichen = null;
 
     /** @Type("DateTime<'Y-m-d\TH:i:s', null, ['Y-m-d\TH:i:sP', 'Y-m-d\TH:i:s']>") */
-    protected ?\DateTime $zvtermin = null;
+    public ?\DateTime $zvtermin = null;
 
     /** @Type("DateTime<'Y-m-d\TH:i:s', null, ['Y-m-d\TH:i:sP', 'Y-m-d\TH:i:s']>") */
-    protected ?\DateTime $zusatztermin = null;
+    public ?\DateTime $zusatztermin = null;
 
     /** @Type("string") */
-    protected ?string $amtsgericht = null;
+    public ?string $amtsgericht = null;
 
     /** @Type("float") */
-    protected ?float $verkehrswert = null;
+    public ?float $verkehrswert = null;
 
     public function getZwangsversteigerung(): ?bool
     {
@@ -102,7 +102,7 @@ class Versteigerung
         ?\DateTime $zvtermin = null,
         ?\DateTime $zusatztermin = null,
         ?string $amtsgericht = null,
-        ?float $verkehrswert = null
+        ?float $verkehrswert = null,
     ) {
         $this->zwangsversteigerung = $zwangsversteigerung;
         $this->aktenzeichen = $aktenzeichen;

--- a/src/API/VerwaltungObjekt.php
+++ b/src/API/VerwaltungObjekt.php
@@ -15,91 +15,91 @@ use JMS\Serializer\Annotation\XmlRoot;
 class VerwaltungObjekt
 {
     /** @Type("bool") */
-    protected ?bool $objektadresseFreigeben = null;
+    public ?bool $objektadresseFreigeben = null;
 
     /** @Type("string") */
-    protected ?string $verfuegbarAb = null;
+    public ?string $verfuegbarAb = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $abdatum = null;
+    public ?\DateTime $abdatum = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $bisdatum = null;
+    public ?\DateTime $bisdatum = null;
 
     /** @Type("Ujamii\OpenImmo\API\MinMietdauer") */
-    protected ?MinMietdauer $minMietdauer = null;
+    public ?MinMietdauer $minMietdauer = null;
 
     /** @Type("Ujamii\OpenImmo\API\MaxMietdauer") */
-    protected ?MaxMietdauer $maxMietdauer = null;
+    public ?MaxMietdauer $maxMietdauer = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $versteigerungstermin = null;
+    public ?\DateTime $versteigerungstermin = null;
 
     /** @Type("bool") */
-    protected ?bool $wbsSozialwohnung = null;
+    public ?bool $wbsSozialwohnung = null;
 
     /** @Type("bool") */
-    protected ?bool $vermietet = null;
+    public ?bool $vermietet = null;
 
     /** @Type("string") */
-    protected ?string $gruppennummer = null;
+    public ?string $gruppennummer = null;
 
     /** @Type("string") */
-    protected ?string $zugang = null;
+    public ?string $zugang = null;
 
     /** @Type("float") */
-    protected ?float $laufzeit = null;
+    public ?float $laufzeit = null;
 
     /**
      * @Type("int")
      * Minimum value (inclusive): 1
      */
-    protected ?int $maxPersonen = null;
+    public ?int $maxPersonen = null;
 
     /** @Type("bool") */
-    protected ?bool $nichtraucher = null;
+    public ?bool $nichtraucher = null;
 
     /** @Type("bool") */
-    protected ?bool $haustiere = null;
+    public ?bool $haustiere = null;
 
     /** @Type("Ujamii\OpenImmo\API\Geschlecht") */
-    protected ?Geschlecht $geschlecht = null;
+    public ?Geschlecht $geschlecht = null;
 
     /** @Type("bool") */
-    protected ?bool $denkmalgeschuetzt = null;
+    public ?bool $denkmalgeschuetzt = null;
 
     /** @Type("bool") */
-    protected ?bool $alsFerien = null;
+    public ?bool $alsFerien = null;
 
     /** @Type("bool") */
-    protected ?bool $gewerblicheNutzung = null;
+    public ?bool $gewerblicheNutzung = null;
 
     /** @Type("string") */
-    protected ?string $branchen = null;
+    public ?string $branchen = null;
 
     /** @Type("bool") */
-    protected ?bool $hochhaus = null;
+    public ?bool $hochhaus = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getObjektadresseFreigeben(): ?bool
     {

--- a/src/API/VerwaltungTechn.php
+++ b/src/API/VerwaltungTechn.php
@@ -15,73 +15,73 @@ use JMS\Serializer\Annotation\XmlRoot;
 class VerwaltungTechn
 {
     /** @Type("string") */
-    protected ?string $objektnrIntern = null;
+    public ?string $objektnrIntern = null;
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $objektnrExtern = '';
+    public string $objektnrExtern = '';
 
     /** @Type("Ujamii\OpenImmo\API\Aktion") */
-    protected ?Aktion $aktion = null;
+    public ?Aktion $aktion = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $aktivVon = null;
+    public ?\DateTime $aktivVon = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $aktivBis = null;
+    public ?\DateTime $aktivBis = null;
 
     /**
      * @Type("string")
      * @SkipWhenEmpty
      */
-    protected string $openimmoObid = '';
+    public string $openimmoObid = '';
 
     /** @Type("string") */
-    protected ?string $kennungUrsprung = null;
+    public ?string $kennungUrsprung = null;
 
     /** @Type("DateTime<'Y-m-d'>") */
-    protected ?\DateTime $standVom = null;
+    public ?\DateTime $standVom = null;
 
     /** @Type("bool") */
-    protected ?bool $weitergabeGenerell = null;
+    public ?bool $weitergabeGenerell = null;
 
     /** @Type("string") */
-    protected ?string $weitergabePositiv = null;
+    public ?string $weitergabePositiv = null;
 
     /** @Type("string") */
-    protected ?string $weitergabeNegativ = null;
+    public ?string $weitergabeNegativ = null;
 
     /** @Type("string") */
-    protected ?string $gruppenKennung = null;
+    public ?string $gruppenKennung = null;
 
     /** @Type("Ujamii\OpenImmo\API\Master") */
-    protected ?Master $master = null;
+    public ?Master $master = null;
 
     /** @Type("string") */
-    protected ?string $sprache = null;
+    public ?string $sprache = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getObjektnrIntern(): ?string
     {

--- a/src/API/Waehrung.php
+++ b/src/API/Waehrung.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class Waehrung
- * Währung
+ * WÃ¤hrung
  * @XmlRoot("waehrung")
  */
 class Waehrung
@@ -202,7 +202,7 @@ class Waehrung
      * optional
      * @see ISO_WAEHRUNG_* constants
      */
-    protected string $isoWaehrung = '';
+    public string $isoWaehrung = '';
 
     public function getIsoWaehrung(): ?string
     {

--- a/src/API/WeitereAdresse.php
+++ b/src/API/WeitereAdresse.php
@@ -20,147 +20,147 @@ class WeitereAdresse
      * @XmlAttribute
      * required
      */
-    protected string $adressart = '';
+    public string $adressart = '';
 
     /** @Type("string") */
-    protected ?string $vorname = null;
+    public ?string $vorname = null;
 
     /** @Type("string") */
-    protected ?string $name = null;
+    public ?string $name = null;
 
     /** @Type("string") */
-    protected ?string $titel = null;
+    public ?string $titel = null;
 
     /** @Type("string") */
-    protected ?string $anrede = null;
+    public ?string $anrede = null;
 
     /** @Type("string") */
-    protected ?string $anredeBrief = null;
+    public ?string $anredeBrief = null;
 
     /** @Type("string") */
-    protected ?string $firma = null;
+    public ?string $firma = null;
 
     /** @Type("string") */
-    protected ?string $zusatzfeld = null;
+    public ?string $zusatzfeld = null;
 
     /** @Type("string") */
-    protected ?string $strasse = null;
+    public ?string $strasse = null;
 
     /** @Type("string") */
-    protected ?string $hausnummer = null;
+    public ?string $hausnummer = null;
 
     /** @Type("string") */
-    protected ?string $plz = null;
+    public ?string $plz = null;
 
     /** @Type("string") */
-    protected ?string $ort = null;
+    public ?string $ort = null;
 
     /** @Type("string") */
-    protected ?string $postfach = null;
+    public ?string $postfach = null;
 
     /** @Type("string") */
-    protected ?string $postfPlz = null;
+    public ?string $postfPlz = null;
 
     /** @Type("string") */
-    protected ?string $postfOrt = null;
+    public ?string $postfOrt = null;
 
     /** @Type("Ujamii\OpenImmo\API\Land") */
-    protected ?Land $land = null;
+    public ?Land $land = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $emailZentrale = null;
+    public ?string $emailZentrale = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $emailDirekt = null;
+    public ?string $emailDirekt = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $emailPrivat = null;
+    public ?string $emailPrivat = null;
 
     /**
      * @XmlList(inline = true, entry = "email_sonstige")
      * @Type("array<Ujamii\OpenImmo\API\EmailSonstige>")
      * @SkipWhenEmpty
      */
-    protected array $emailSonstige = [];
+    public array $emailSonstige = [];
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telDurchw = null;
+    public ?string $telDurchw = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telZentrale = null;
+    public ?string $telZentrale = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telHandy = null;
+    public ?string $telHandy = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telFax = null;
+    public ?string $telFax = null;
 
     /**
      * @Type("string")
      * Minimum length: 1
      */
-    protected ?string $telPrivat = null;
+    public ?string $telPrivat = null;
 
     /**
      * @XmlList(inline = true, entry = "tel_sonstige")
      * @Type("array<Ujamii\OpenImmo\API\TelSonstige>")
      * @SkipWhenEmpty
      */
-    protected array $telSonstige = [];
+    public array $telSonstige = [];
 
     /** @Type("string") */
-    protected ?string $url = null;
+    public ?string $url = null;
 
     /** @Type("bool") */
-    protected ?bool $adressfreigabe = null;
+    public ?bool $adressfreigabe = null;
 
     /** @Type("string") */
-    protected ?string $personennummer = null;
+    public ?string $personennummer = null;
 
     /** @Type("string") */
-    protected ?string $freitextfeld = null;
+    public ?string $freitextfeld = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getAdressart(): string
     {

--- a/src/API/Wohnung.php
+++ b/src/API/Wohnung.php
@@ -34,7 +34,7 @@ class Wohnung
      * optional
      * @see WOHNUNGTYP_* constants
      */
-    protected string $wohnungtyp = '';
+    public string $wohnungtyp = '';
 
     public function getWohnungtyp(): ?string
     {

--- a/src/API/Zimmer.php
+++ b/src/API/Zimmer.php
@@ -21,7 +21,7 @@ class Zimmer
      * optional
      * @see ZIMMERTYP_* constants
      */
-    protected string $zimmertyp = '';
+    public string $zimmertyp = '';
 
     public function getZimmertyp(): ?string
     {

--- a/src/API/ZinshausRenditeobjekt.php
+++ b/src/API/ZinshausRenditeobjekt.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 
 /**
  * Class ZinshausRenditeobjekt
- * Objektyp / Typ f. Zins und Renditehäuser
+ * Objektyp / Typ f. Zins und RenditehÃ¤user
  * @XmlRoot("zinshaus_renditeobjekt")
  */
 class ZinshausRenditeobjekt
@@ -33,7 +33,7 @@ class ZinshausRenditeobjekt
      * optional
      * @see ZINS_TYP_* constants
      */
-    protected string $zinsTyp = '';
+    public string $zinsTyp = '';
 
     public function getZinsTyp(): ?string
     {

--- a/src/API/Zustand.php
+++ b/src/API/Zustand.php
@@ -36,7 +36,7 @@ class Zustand
      * optional
      * @see ZUSTAND_ART_* constants
      */
-    protected string $zustandArt = '';
+    public string $zustandArt = '';
 
     public function getZustandArt(): ?string
     {

--- a/src/API/ZustandAngaben.php
+++ b/src/API/ZustandAngaben.php
@@ -15,62 +15,62 @@ use JMS\Serializer\Annotation\XmlRoot;
 class ZustandAngaben
 {
     /** @Type("string") */
-    protected ?string $baujahr = null;
+    public ?string $baujahr = null;
 
     /** @Type("string") */
-    protected ?string $letztemodernisierung = null;
+    public ?string $letztemodernisierung = null;
 
     /** @Type("Ujamii\OpenImmo\API\Zustand") */
-    protected ?Zustand $zustand = null;
+    public ?Zustand $zustand = null;
 
     /** @Type("Ujamii\OpenImmo\API\Alter") */
-    protected ?Alter $alter = null;
+    public ?Alter $alter = null;
 
     /** @Type("Ujamii\OpenImmo\API\BebaubarNach") */
-    protected ?BebaubarNach $bebaubarNach = null;
+    public ?BebaubarNach $bebaubarNach = null;
 
     /** @Type("Ujamii\OpenImmo\API\Erschliessung") */
-    protected ?Erschliessung $erschliessung = null;
+    public ?Erschliessung $erschliessung = null;
 
     /** @Type("Ujamii\OpenImmo\API\ErschliessungUmfang") */
-    protected ?ErschliessungUmfang $erschliessungUmfang = null;
+    public ?ErschliessungUmfang $erschliessungUmfang = null;
 
     /** @Type("string") */
-    protected ?string $bauzone = null;
+    public ?string $bauzone = null;
 
     /** @Type("string") */
-    protected ?string $altlasten = null;
+    public ?string $altlasten = null;
 
     /**
      * @XmlList(inline = true, entry = "energiepass")
      * @Type("array<Ujamii\OpenImmo\API\Energiepass>")
      * @SkipWhenEmpty
      */
-    protected array $energiepass = [];
+    public array $energiepass = [];
 
     /** @Type("Ujamii\OpenImmo\API\Verkaufstatus") */
-    protected ?Verkaufstatus $verkaufstatus = null;
+    public ?Verkaufstatus $verkaufstatus = null;
 
     /**
      * @XmlList(inline = true, entry = "user_defined_simplefield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedSimplefield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedSimplefield = [];
+    public array $userDefinedSimplefield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_anyfield")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedAnyfield>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedAnyfield = [];
+    public array $userDefinedAnyfield = [];
 
     /**
      * @XmlList(inline = true, entry = "user_defined_extend")
      * @Type("array<Ujamii\OpenImmo\API\UserDefinedExtend>")
      * @SkipWhenEmpty
      */
-    protected array $userDefinedExtend = [];
+    public array $userDefinedExtend = [];
 
     public function getBaujahr(): ?string
     {

--- a/src/Generator/ApiGenerator.php
+++ b/src/Generator/ApiGenerator.php
@@ -138,7 +138,7 @@ class ApiGenerator
     {
         $propertyName  = 'value';
         $classProperty = $class->addProperty($propertyName)
-                               ->setVisibility(ClassType::VisibilityProtected);
+                               ->setVisibility(ClassType::VisibilityPublic);
 
         if (is_null($extension)) {
             $xsdType = 'string';
@@ -195,7 +195,7 @@ class ApiGenerator
             return;
         }
         $classProperty = $class->addProperty($propertyName)
-                               ->setVisibility(ClassType::VisibilityProtected);
+                               ->setVisibility(ClassType::VisibilityPublic);
         $xsdType       = $this->getPhpPropertyTypeFromXsdElement($property);
 
         // take min/max into account, as this may be an array instead
@@ -281,7 +281,7 @@ class ApiGenerator
     {
         $propertyName  = TypeUtil::camelize(strtolower($attribute->getName()), true);
         $classProperty = $class->addProperty($propertyName)
-                               ->setVisibility(ClassType::VisibilityProtected);
+                               ->setVisibility(ClassType::VisibilityPublic);
         $xsdType       = TypeUtil::extractTypeForPhp($attribute->getType());
         $phpType       = TypeUtil::getValidPhpType($xsdType);
         $classProperty->addComment('@Type("' . TypeUtil::getTypeForSerializer($xsdType) . '")');
@@ -329,7 +329,6 @@ class ApiGenerator
     {
         foreach ($restriction->getChecks() as $type => $options) {
             switch ($type) {
-
                 case 'enumeration':
                     $constantPrefix = strtoupper($nameInXsd . '_');
                     foreach ($options as $possibleValue) {
@@ -365,7 +364,6 @@ class ApiGenerator
 
                 default:
                     throw new \InvalidArgumentException(vsprintf('Type "%s" is not handled in %s->parseAttribute', [$type, __CLASS__]));
-
             }
         }
     }


### PR DESCRIPTION
This pull request changes all properties from `protected` to `public`. This is quite usefull if you want to call `json_encode` on the `Openimmo` object. This makes serializing and storing the object in a database or a memcache instance a lot easier.

There is no security downside from having the properties beeing `public`. 